### PR TITLE
[Feature/REST] Pagination by index for address|scripthash txs/chain endpoint

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -615,16 +615,22 @@ impl FromStr for AddressPaginator {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Txid::from_hex(s)
-            .ok()
-            .and_then(|txid| Some(Self::Txid(txid)))
-            .or_else(|| {
-                s.parse::<usize>()
-                    .ok()
-                    .filter(|&skip| skip != 0) // Don't allow 0 for Skip
-                    .and_then(|skip| Some(Self::Skip(skip)))
-            })
-            .ok_or("Invalid AddressPaginator".to_string())
+        // 1) Deal with Options in if else statement
+        //    to utilize filter for usize.
+        // 2) 64 length usize doesn't exist,
+        //    and from_hex is expensive.
+        if s.len() == 64 {
+            Txid::from_hex(s)
+                .ok()
+                .and_then(|txid| Some(Self::Txid(txid)))
+        } else {
+            s.parse::<usize>()
+                .ok()
+                .filter(|&skip| skip != 0) // Don't allow 0 for Skip
+                .and_then(|skip| Some(Self::Skip(skip)))
+        }
+        // 3) Convert the return value of the if else statement into a Result.
+        .ok_or("Invalid AddressPaginator".to_string())
     }
 }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -620,6 +620,7 @@ impl FromStr for AddressPaginator {
             .or_else(|| {
                 s.parse::<usize>()
                     .ok()
+                    .filter(|&skip| skip != 0) // Don't allow 0 for Skip
                     .and_then(|skip| Some(Self::Skip(skip)))
             })
             .ok_or("Invalid AddressPaginator".to_string())


### PR DESCRIPTION
---

### Requires re-index? == **No**
### Affects API interface AND/OR response data format? == **You can now pass an integer instead of a txid for the /txs/chain endpoint**

---

Mempool (which relies on this endpoint for its address pages) currently can only implement "next page" on the address page since there is no way to skip a certain number of transactions.

ie. If an address has 100 transactions, right now it shows the first 25 and you have to click "show more" and it fetches the next 25 with the last_seen_txid of the last tx on the current page.

With this patch, they can provide links numbered 1, 2, 3, 4, and clicking on 3 will pass "50" instead of the hex txid, which will skip the first 50 transactions and display starting from the 51st transaction.

If there are other endpoints you'd like to be index-paginated where they used to be hex id paginated, we can do something similar as well.