### PR TITLE
Fix crashes for unknown Outpoint

### DIFF
--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -74,7 +74,7 @@ impl Query {
         self.mempool
             .write()
             .unwrap()
-            .add_by_txid(&self.daemon, &txid);
+            .add_by_txid(&self.daemon, &txid)?;
         Ok(txid)
     }
 
@@ -118,11 +118,9 @@ impl Query {
             .or_else(|| self.mempool().lookup_raw_txn(txid))
     }
 
-    pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {
+    pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> Result<HashMap<OutPoint, TxOut>> {
         // the mempool lookup_txos() internally looks up confirmed txos as well
-        self.mempool()
-            .lookup_txos(outpoints)
-            .expect("failed loading txos")
+        self.mempool().lookup_txos(outpoints)
     }
 
     pub fn lookup_spend(&self, outpoint: &OutPoint) -> Option<SpendingInput> {


### PR DESCRIPTION
There is a reoccurring issue where not found Outpoints crashes esplora.

This handles them properly and will return a 500 response to the REST client.

There were a few other uses that bubble up into functions that already had error handling.