### PR TITLE
Feature: Allow mempool and confirmed transactions to be queried with txid

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -468,6 +468,12 @@ impl ChainQuery {
         self._history(b'H', scripthash, last_seen_txid, limit)
     }
 
+    pub fn history_txids_iter<'a>(&'a self, scripthash: &[u8]) -> impl Iterator<Item = Txid> + 'a {
+        self.history_iter_scan_reverse(b'H', scripthash)
+            .map(|row| TxHistoryRow::from_row(row).get_txid())
+            .unique()
+    }
+
     fn _history(
         &self,
         code: u8,


### PR DESCRIPTION
---

### Requires re-index? == **No**
### Affects API interface AND/OR response data format? == **Adds `max_txs` query parameter to /txs, /txs/mempool, and /txs/chain, and adds `after_txid` query parameter to /txs. These parameters will modify the number of transactions returned on a per-request basis.**

---

This also allows for all the address/ADDRESS/txs/* endpoints to be queried with max_txs query parameter, which will cap the amount of response transactions.

This will fix the 25 mempool transaction breakage.

This requires fixing the frontend as well.

1. address.component `loadMore` function must not assume all loaded transactions are confirmed. You need to look at the status of the returned value.
2. If the request returns a 422 response `"after_txid not found"` as the body, you should refresh the address page (could not find the mempool transaction anywhere.)
3. loadMore should call the `/api/address/{ADDRESS}/txs` endpoint with `?after_txid={TXID}` query parameter.