### PR TITLE
Bump version to match mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "electrs"
-version = "0.4.1"
+version = "2.6.0-dev"
 dependencies = [
  "arraydeque",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrs"
-version = "0.4.1"
+version = "2.6.0-dev"
 authors = ["Roman Zeyde <me@romanzey.de>"]
 description = "An efficient re-implementation of Electrum Server in Rust"
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,7 +365,7 @@ impl Config {
         let cookie = m.value_of("cookie").map(|s| s.to_owned());
 
         let electrum_banner = m.value_of("electrum_banner").map_or_else(
-            || format!("Welcome to electrs-esplora {}", ELECTRS_VERSION),
+            || format!("Welcome to mempool-electrs {}", ELECTRS_VERSION),
             |s| s.into(),
         );
 


### PR DESCRIPTION
Note: This is changing the default value for the Electrum server banner (which is broadcast to other Electrum peers).

However, this value can be overridden by a parameter arg at startup, so it might be worth it to just change the startup params in production.

Changing this default would be good to see how many Electrum servers are running mempool fork, though.