### PR TITLE
Bulk mempool txs

### DIFF
--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -6,11 +6,11 @@ use bitcoin::consensus::encode::serialize;
 #[cfg(feature = "liquid")]
 use elements::{encode::serialize, AssetId};
 
-use std::collections::{BTreeSet, BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
+use std::ops::Bound::{Excluded, Unbounded};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::ops::Bound::{Excluded, Unbounded};
 
 use crate::chain::{deserialize, Network, OutPoint, Transaction, TxOut, Txid};
 use crate::config::Config;
@@ -302,10 +302,11 @@ impl Mempool {
         let mut page = Vec::with_capacity(n);
         let start_bound = match start {
             Some(txid) => Excluded(txid),
-            None => Unbounded
+            None => Unbounded,
         };
 
-        self.txstore.range((start_bound, Unbounded))
+        self.txstore
+            .range((start_bound, Unbounded))
             .take(n)
             .for_each(|(_, value)| {
                 page.push(value.clone());

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -305,14 +305,11 @@ impl Mempool {
             None => Unbounded
         };
 
-        let mut iter = self.txstore.range((start_bound, Unbounded)).peekable();
-        for _ in 0..n {
-            if let Some((_, value)) = iter.next() {
+        self.txstore.range((start_bound, Unbounded))
+            .take(n)
+            .for_each(|(_, value)| {
                 page.push(value.clone());
-            } else {
-                break;
-            }
-        }
+            });
 
         page
     }

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -289,6 +289,12 @@ impl Mempool {
         self.txstore.keys().collect()
     }
 
+    // Get all txs in the mempool
+    pub fn txs(&self) -> Vec<Transaction> {
+        let _timer = self.latency.with_label_values(&["txs"]).start_timer();
+        self.txstore.values().cloned().collect()
+    }
+
     // Get an overview of the most recent transactions
     pub fn recent_txs_overview(&self) -> Vec<&TxOverview> {
         // We don't bother ever deleting elements from the recent list.

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -6,10 +6,11 @@ use bitcoin::consensus::encode::serialize;
 #[cfg(feature = "liquid")]
 use elements::{encode::serialize, AssetId};
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, BTreeMap, HashMap, HashSet};
 use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::ops::Bound::{Excluded, Unbounded};
 
 use crate::chain::{deserialize, Network, OutPoint, Transaction, TxOut, Txid};
 use crate::config::Config;
@@ -29,7 +30,7 @@ use crate::elements::asset;
 pub struct Mempool {
     chain: Arc<ChainQuery>,
     config: Arc<Config>,
-    txstore: HashMap<Txid, Transaction>,
+    txstore: BTreeMap<Txid, Transaction>,
     feeinfo: HashMap<Txid, TxFeeInfo>,
     history: HashMap<FullHash, Vec<TxHistoryInfo>>, // ScriptHash -> {history_entries}
     edges: HashMap<OutPoint, (Txid, u32)>,          // OutPoint -> (spending_txid, spending_vin)
@@ -62,7 +63,7 @@ impl Mempool {
     pub fn new(chain: Arc<ChainQuery>, metrics: &Metrics, config: Arc<Config>) -> Self {
         Mempool {
             chain,
-            txstore: HashMap::new(),
+            txstore: BTreeMap::new(),
             feeinfo: HashMap::new(),
             history: HashMap::new(),
             edges: HashMap::new(),
@@ -293,6 +294,27 @@ impl Mempool {
     pub fn txs(&self) -> Vec<Transaction> {
         let _timer = self.latency.with_label_values(&["txs"]).start_timer();
         self.txstore.values().cloned().collect()
+    }
+
+    // Get n txs after the given txid in the mempool
+    pub fn txs_page(&self, n: usize, start: Option<Txid>) -> Vec<Transaction> {
+        let _timer = self.latency.with_label_values(&["txs"]).start_timer();
+        let mut page = Vec::with_capacity(n);
+        let start_bound = match start {
+            Some(txid) => Excluded(txid),
+            None => Unbounded
+        };
+
+        let mut iter = self.txstore.range((start_bound, Unbounded)).peekable();
+        for _ in 0..n {
+            if let Some((_, value)) = iter.next() {
+                page.push(value.clone());
+            } else {
+                break;
+            }
+        }
+
+        page
     }
 
     // Get an overview of the most recent transactions

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1083,6 +1083,16 @@ fn handle_request(
         (&Method::GET, Some(&"mempool"), Some(&"txids"), None, None, None) => {
             json_response(query.mempool().txids(), TTL_SHORT)
         }
+        (&Method::GET, Some(&"mempool"), Some(&"txs"), None, None, None) => {
+            let txs = query
+                .mempool()
+                .txs()
+                .into_iter()
+                .map(|tx| (tx, None))
+                .collect();
+
+            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+        }
         (&Method::GET, Some(&"mempool"), Some(&"recent"), None, None, None) => {
             let mempool = query.mempool();
             let recent = mempool.recent_txs_overview();

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1083,10 +1083,21 @@ fn handle_request(
         (&Method::GET, Some(&"mempool"), Some(&"txids"), None, None, None) => {
             json_response(query.mempool().txids(), TTL_SHORT)
         }
-        (&Method::GET, Some(&"mempool"), Some(&"txs"), None, None, None) => {
+        (&Method::GET, Some(&"mempool"), Some(&"txs"), Some(&"all"), None, None) => {
             let txs = query
                 .mempool()
                 .txs()
+                .into_iter()
+                .map(|tx| (tx, None))
+                .collect();
+
+            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+        }
+        (&Method::GET, Some(&"mempool"), Some(&"txs"), last_seen_txid, None, None) => {
+            let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
+            let txs = query
+                .mempool()
+                .txs_page(10_000, last_seen_txid)
                 .into_iter()
                 .map(|tx| (tx, None))
                 .collect();


### PR DESCRIPTION
Synchronizing the mempool one-by-one with individual `/tx/:txid` requests is extremely slow when the mempool is large.

This PR adds a (very naïve) bulk `/mempool/txs` endpoint which returns the entire mempool in a single query.

Ideally this would be a paginated endpoint with more manageable response sizes, but the single bulk endpoint does seem to work for now.

This is used in [a draft PR in the mempool backend](https://github.com/mempool/mempool/pull/4025) to massively reduce startup time.