### PR TITLE
Bulk block txs

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -371,6 +371,34 @@ impl ChainQuery {
         }
     }
 
+    pub fn get_block_txs(&self, hash: &BlockHash) -> Option<Vec<Transaction>> {
+        let _timer = self.start_timer("get_block_txs");
+
+        let txids: Option<Vec<Txid>> = if self.light_mode {
+            // TODO fetch block as binary from REST API instead of as hex
+            let mut blockinfo = self.daemon.getblock_raw(hash, 1).ok()?;
+            Some(serde_json::from_value(blockinfo["tx"].take()).unwrap())
+        } else {
+            self.store
+                .txstore_db
+                .get(&BlockRow::txids_key(full_hash(&hash[..])))
+                .map(|val| bincode::deserialize(&val).expect("failed to parse block txids"))
+        };
+
+        txids.and_then(|txid_vec| {
+            let mut transactions = Vec::new();
+
+            for txid in txid_vec {
+                match self.lookup_txn(&txid, Some(hash)) {
+                    Some(transaction) => transactions.push(transaction),
+                    None => return None,
+                }
+            }
+
+            Some(transactions)
+        })
+    }
+
     pub fn get_block_meta(&self, hash: &BlockHash) -> Option<BlockMeta> {
         let _timer = self.start_timer("get_block_meta");
 

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -386,7 +386,7 @@ impl ChainQuery {
         };
 
         txids.and_then(|txid_vec| {
-            let mut transactions = Vec::new();
+            let mut transactions = Vec::with_capacity(txid_vec.len());
 
             for txid in txid_vec {
                 match self.lookup_txn(&txid, Some(hash)) {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -699,6 +699,18 @@ fn handle_request(
                 .ok_or_else(|| HttpError::not_found("Block not found".to_string()))?;
             json_response(txids, TTL_LONG)
         }
+        (&Method::GET, Some(&"block"), Some(hash), Some(&"txs"), None, None) => {
+            let hash = BlockHash::from_hex(hash)?;
+            let txs = query
+                .chain()
+                .get_block_txs(&hash)
+                .ok_or_else(|| HttpError::not_found("Block not found".to_string()))?
+                .into_iter()
+                .map(|tx| (tx, None))
+                .collect();
+
+            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+        }
         (&Method::GET, Some(&"block"), Some(hash), Some(&"header"), None, None) => {
             let hash = BlockHash::from_hex(hash)?;
             let header = query


### PR DESCRIPTION
Adds a `/block/:hash/txs` endpoint which returns full transaction data for the requested block hash.

Used by https://github.com/mempool/mempool/pull/4045 to speed up block processing.