### PR TITLE
Fix: mempool.update() frequent crashes in the main loop

### DIFF
--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -343,7 +343,9 @@ impl Mempool {
             }
         };
         // Add new transactions
-        self.add(to_add);
+        if to_add.len() > self.add(to_add) {
+            debug!("Mempool update added less transactions than expected");
+        }
         // Remove missing transactions
         self.remove(to_remove);
 
@@ -382,6 +384,7 @@ impl Mempool {
     /// Add transactions to the mempool.
     ///
     /// The return value is the number of transactions processed.
+    #[must_use = "Must deal with [[input vec's length]] > [[result]]."]
     fn add(&mut self, txs: Vec<Transaction>) -> usize {
         self.delta
             .with_label_values(&["add"])

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -292,6 +292,7 @@ impl Indexer {
     }
 
     fn add(&self, blocks: &[BlockEntry]) {
+        debug!("Adding {} blocks to Indexer", blocks.len());
         // TODO: skip orphaned blocks?
         let rows = {
             let _timer = self.start_timer("add_process");
@@ -310,6 +311,7 @@ impl Indexer {
     }
 
     fn index(&self, blocks: &[BlockEntry]) {
+        debug!("Indexing {} blocks with Indexer", blocks.len());
         let previous_txos_map = {
             let _timer = self.start_timer("index_lookup");
             lookup_txos(&self.store.txstore_db, &get_previous_txos(blocks), false)

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -981,9 +981,8 @@ fn handle_request(
             let ttl = ttl_by_depth(blockid.as_ref().map(|b| b.height), query);
 
             let mut tx = prepare_txs(vec![(tx, blockid)], query, config);
-            tx.remove(0);
 
-            json_response(tx, ttl)
+            json_response(tx.remove(0), ttl)
         }
         (&Method::GET, Some(&"tx"), Some(hash), Some(out_type @ &"hex"), None, None)
         | (&Method::GET, Some(&"tx"), Some(hash), Some(out_type @ &"raw"), None, None) => {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -502,7 +502,7 @@ fn prepare_txs(
     txs: Vec<(Transaction, Option<BlockId>)>,
     query: &Query,
     config: &Config,
-) -> Result<Vec<TransactionValue>, errors::Error> {
+) -> Vec<TransactionValue> {
     let outpoints = txs
         .iter()
         .flat_map(|(tx, _)| {
@@ -513,12 +513,11 @@ fn prepare_txs(
         })
         .collect();
 
-    let prevouts = query.lookup_txos(&outpoints)?;
+    let prevouts = query.lookup_txos(&outpoints);
 
-    Ok(txs
-        .into_iter()
+    txs.into_iter()
         .map(|(tx, blockid)| TransactionValue::new(tx, blockid, &prevouts, config))
-        .collect())
+        .collect()
 }
 
 #[tokio::main]
@@ -709,7 +708,7 @@ fn handle_request(
                 .map(|tx| (tx, None))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
         (&Method::GET, Some(&"block"), Some(hash), Some(&"header"), None, None) => {
             let hash = BlockHash::from_hex(hash)?;
@@ -786,7 +785,7 @@ fn handle_request(
             // XXX orphraned blocks alway get TTL_SHORT
             let ttl = ttl_by_depth(confirmed_blockid.map(|b| b.height), query);
 
-            json_maybe_error_response(prepare_txs(txs, query, config), ttl)
+            json_response(prepare_txs(txs, query, config), ttl)
         }
         (&Method::GET, Some(script_type @ &"address"), Some(script_str), None, None, None)
         | (&Method::GET, Some(script_type @ &"scripthash"), Some(script_str), None, None, None) => {
@@ -874,7 +873,7 @@ fn handle_request(
                 );
             }
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
 
         (
@@ -907,7 +906,7 @@ fn handle_request(
                 .map(|(tx, blockid)| (tx, Some(blockid)))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
         (
             &Method::GET,
@@ -938,7 +937,7 @@ fn handle_request(
                 .map(|tx| (tx, None))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
 
         (
@@ -981,9 +980,10 @@ fn handle_request(
             let blockid = query.chain().tx_confirming_block(&hash);
             let ttl = ttl_by_depth(blockid.as_ref().map(|b| b.height), query);
 
-            let tx = prepare_txs(vec![(tx, blockid)], query, config).map(|mut v| v.remove(0));
+            let mut tx = prepare_txs(vec![(tx, blockid)], query, config);
+            tx.remove(0);
 
-            json_maybe_error_response(tx, ttl)
+            json_response(tx, ttl)
         }
         (&Method::GET, Some(&"tx"), Some(hash), Some(out_type @ &"hex"), None, None)
         | (&Method::GET, Some(&"tx"), Some(hash), Some(out_type @ &"raw"), None, None) => {
@@ -1106,7 +1106,7 @@ fn handle_request(
                 .map(|tx| (tx, None))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
         (&Method::GET, Some(&"mempool"), Some(&"txs"), last_seen_txid, None, None) => {
             let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
@@ -1117,7 +1117,7 @@ fn handle_request(
                 .map(|tx| (tx, None))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
         (&Method::GET, Some(&"mempool"), Some(&"recent"), None, None, None) => {
             let mempool = query.mempool();
@@ -1188,7 +1188,7 @@ fn handle_request(
                     .map(|(tx, blockid)| (tx, Some(blockid))),
             );
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
 
         #[cfg(feature = "liquid")]
@@ -1214,7 +1214,7 @@ fn handle_request(
                 .map(|(tx, blockid)| (tx, Some(blockid)))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
 
         #[cfg(feature = "liquid")]
@@ -1228,7 +1228,7 @@ fn handle_request(
                 .map(|tx| (tx, None))
                 .collect();
 
-            json_maybe_error_response(prepare_txs(txs, query, config), TTL_SHORT)
+            json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
 
         #[cfg(feature = "liquid")]
@@ -1281,26 +1281,26 @@ fn json_response<T: Serialize>(value: T, ttl: u32) -> Result<Response<Body>, Htt
         .unwrap())
 }
 
-fn json_maybe_error_response<T: Serialize>(
-    value: Result<T, errors::Error>,
-    ttl: u32,
-) -> Result<Response<Body>, HttpError> {
-    let response = Response::builder()
-        .header("Content-Type", "application/json")
-        .header("Cache-Control", format!("public, max-age={:}", ttl))
-        .header("X-Powered-By", &**VERSION_STRING);
-    Ok(match value {
-        Ok(v) => response
-            .body(Body::from(serde_json::to_string(&v)?))
-            .expect("Valid http response"),
-        Err(e) => response
-            .status(500)
-            .body(Body::from(serde_json::to_string(
-                &json!({ "error": e.to_string() }),
-            )?))
-            .expect("Valid http response"),
-    })
-}
+// fn json_maybe_error_response<T: Serialize>(
+//     value: Result<T, errors::Error>,
+//     ttl: u32,
+// ) -> Result<Response<Body>, HttpError> {
+//     let response = Response::builder()
+//         .header("Content-Type", "application/json")
+//         .header("Cache-Control", format!("public, max-age={:}", ttl))
+//         .header("X-Powered-By", &**VERSION_STRING);
+//     Ok(match value {
+//         Ok(v) => response
+//             .body(Body::from(serde_json::to_string(&v)?))
+//             .expect("Valid http response"),
+//         Err(e) => response
+//             .status(500)
+//             .body(Body::from(serde_json::to_string(
+//                 &json!({ "error": e.to_string() }),
+//             )?))
+//             .expect("Valid http response"),
+//     })
+// }
 
 fn blocks(
     query: &Query,


### PR DESCRIPTION
After fixing one more bug with mempool syncing, @wiz Showed me the logs from the fix, and I noticed `WARN - lookup txouts failed: missing outpoint OutPoint { txid: ee7ecd96379b6685d600f697eb6c3267a4f2d4ec4292000fafdabda1a1024500, vout: 0 }` log (which was my missing Outpoint panic fix from a while back.

I looked into it further, and I thought of a way to make this error state handled much better.

1. Old version (pre Outpoint error fix) = When updating the mempool, if we can't find the parent transactions of any of the transactions we are trying to add, we panicked. (really bad, since RBF etc. and other random reasons cause these kinds of issues all the time.
2. Current version: Instead of panicking, it returns an error and skip the mempool update altogether.

This version changes two things:

1. When creating the parent TxOut map, if a parent TxOut can't be found, it will just not be included in the txos HashMap.
2. When trying to parse the transactions, if any of the parents are missing, `continue;` to the next loop, only skipping the current transaction, but parsing and caching the ones that succeed.

As an added bonus, this removes the need to return Result from a function that is used many places (and was most of the "error propagation work" that I had to do in my first fix.