### PR TITLE
Fix: TcpStream error handling

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -184,7 +184,7 @@ impl Connection {
             .chain_err(|| {
                 ErrorKind::Connection("disconnected from daemon while receiving".to_owned())
             })?
-            .chain_err(|| "failed to read status")?;
+            .chain_err(|| ErrorKind::Connection("failed to read status".to_owned()))?;
         let mut headers = HashMap::new();
         for line in iter {
             let line = line.chain_err(|| ErrorKind::Connection("failed to read".to_owned()))?;


### PR DESCRIPTION
This was causing an error:

```
ERROR - server failed: Error: failed to update mempool from daemon
Caused by: failed to read status
Caused by: Connection reset by peer (os error 54)
```

This fixes it because up in the call stack it was handling ErrorKind::Connection errors only.

Since this chain_err is definitely related to Connection, it should be propagated as such.