### PR TITLE
Bulk mempool query by txid

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -12,7 +12,7 @@ use crate::util::{
 use {bitcoin::consensus::encode, std::str::FromStr};
 
 use bitcoin::blockdata::opcodes;
-use bitcoin::hashes::hex::{Error as HashHexError, FromHex, ToHex};
+use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Error as HashError;
 use hex::{self, FromHexError};
 use hyper::service::{make_service_fn, service_fn};
@@ -1135,7 +1135,7 @@ fn handle_request(
             match txid_strings
                 .into_iter()
                 .map(|txid| Txid::from_hex(&txid))
-                .collect::<Result<Vec<Txid>, HashHexError>>()
+                .collect::<Result<Vec<Txid>, _>>()
             {
                 Ok(txids) => {
                     let txs: Vec<(Transaction, Option<BlockId>)> = {
@@ -1146,7 +1146,7 @@ fn handle_request(
                             .collect()
                     };
 
-                    json_response(prepare_txs(txs, query, config), TTL_SHORT)
+                    json_response(prepare_txs(txs, query, config), 0)
                 }
                 Err(err) => http_message(StatusCode::BAD_REQUEST, err.to_string(), 0),
             }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1138,10 +1138,13 @@ fn handle_request(
                 .collect::<Result<Vec<Txid>, HashHexError>>()
             {
                 Ok(txids) => {
-                    let txs: Vec<(Transaction, Option<BlockId>)> = txids
-                        .iter()
-                        .filter_map(|txid| query.mempool().lookup_txn(txid).map(|tx| (tx, None)))
-                        .collect();
+                    let txs: Vec<(Transaction, Option<BlockId>)> = {
+                        let mempool = query.mempool();
+                        txids
+                            .iter()
+                            .filter_map(|txid| mempool.lookup_txn(txid).map(|tx| (tx, None)))
+                            .collect()
+                    };
 
                     json_response(prepare_txs(txs, query, config), TTL_SHORT)
                 }


### PR DESCRIPTION
This PR adds a new `/mempool/txs` POST endpoint which accepts an array of txids and returns a list of matching transactions from the mempool. Missing or confirmed transactions are omitted from the response.

We could also implement this as a GET endpoint taking the txids as a query param (or even a GET with a request body), but I think the POST approach is cleaner.

This complements the paginated `/mempool/txs` GET endpoint added in #18, allowing us to quickly sync missing transactions when we don't need to whole mempool.

Used to speed up mempool updates in https://github.com/mempool/mempool/pull/4085