### PR TITLE
fix missing prevout tx fee underflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Clippy with Features = ${{ matrix.features }}
-        run: cargo clippy ${{ matrix.features }}
+        run: cargo clippy ${{ matrix.features }} -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,23 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@1.70
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with: # test cache key is different (adding test cfg is a re-compile)
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo test --package electrs --lib --all-features
+
   clippy:
     name: Linter
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 *.sublime*
 *~
 *.pyc
+.vscode

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -56,3 +56,7 @@ cargo clippy $@ -q -F liquid
 TESTNAME="Running cargo clippy check electrum-discovery + liquid"
 echo "$TESTNAME"
 cargo clippy $@ -q -F electrum-discovery,liquid
+
+TESTNAME="Running cargo test with all features"
+echo "$TESTNAME"
+cargo test $@ -q --package electrs --lib --all-features

--- a/src/electrum/discovery.rs
+++ b/src/electrum/discovery.rs
@@ -531,20 +531,26 @@ mod tests {
     const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(1, 4);
 
     #[test]
+    #[ignore = "This test requires external connection to server that no longer exists"]
     fn test() -> Result<()> {
         stderrlog::new().verbosity(4).init().unwrap();
+
+        #[cfg(feature = "liquid")]
+        let testnet = Network::LiquidTestnet;
+        #[cfg(not(feature = "liquid"))]
+        let testnet = Network::Testnet;
 
         let features = ServerFeatures {
             hosts: serde_json::from_str("{\"test.foobar.example\":{\"tcp_port\":60002}}").unwrap(),
             server_version: VERSION_STRING.clone(),
-            genesis_hash: genesis_hash(Network::Testnet),
+            genesis_hash: genesis_hash(testnet),
             protocol_min: PROTOCOL_VERSION,
             protocol_max: PROTOCOL_VERSION,
             hash_function: "sha256".into(),
             pruning: None,
         };
         let discovery = Arc::new(DiscoveryManager::new(
-            Network::Testnet,
+            testnet,
             features,
             PROTOCOL_VERSION,
             false,

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -422,7 +422,7 @@ impl Mempool {
         for txid in txids {
             let tx = self.txstore.get(&txid).expect("missing tx from txstore");
 
-            let prevouts = match extract_tx_prevouts(tx, &txos, false) {
+            let prevouts = match extract_tx_prevouts(tx, &txos) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Skipping tx {txid} missing parent error: {e}");

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -127,6 +127,7 @@ impl Query {
             .or_else(|| self.mempool().lookup_raw_txn(txid))
     }
 
+    /// Not all OutPoints from mempool transactions are guaranteed to be included in the result
     pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {
         // the mempool lookup_txos() internally looks up confirmed txos as well
         self.mempool().lookup_txos(outpoints)

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -155,8 +155,8 @@ impl TransactionValue {
         blockid: Option<BlockId>,
         txos: &HashMap<OutPoint, TxOut>,
         config: &Config,
-    ) -> Result<TransactionValue, errors::Error> {
-        let prevouts = extract_tx_prevouts(&tx, txos, false)?;
+    ) -> Result<Self, errors::Error> {
+        let prevouts = extract_tx_prevouts(&tx, txos)?;
 
         let vins: Vec<TxInValue> = tx
             .input
@@ -174,9 +174,9 @@ impl TransactionValue {
 
         let fee = get_tx_fee(&tx, &prevouts, config.network_type);
 
+        #[allow(clippy::unnecessary_cast)]
         Ok(TransactionValue {
             txid: tx.txid(),
-            #[allow(clippy::unnecessary_cast)]
             version: tx.version as u32,
             locktime: tx.lock_time,
             vin: vins,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -522,12 +522,6 @@ fn ttl_by_depth(height: Option<usize>, query: &Query) -> u32 {
 /// Prepare transactions to be serialized in a JSON response
 ///
 /// Any transactions with missing prevouts will be filtered out of the response, rather than returned with incorrect data.
-///
-/// ## Arguments
-///
-/// * `txs`
-/// * `query`
-/// * `config`
 fn prepare_txs(
     txs: Vec<(Transaction, Option<BlockId>)>,
     query: &Query,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -525,6 +525,16 @@ fn ttl_by_depth(height: Option<usize>, query: &Query) -> u32 {
     })
 }
 
+/// Prepare transactions to be serialized in a JSON response
+///
+/// ## Arguments
+///
+/// * `txs`
+/// * `query`
+/// * `config`
+/// * `filter_missing_prevouts` - boolean flag indicating whether transactions with missing prevouts should be filtered out of the response.
+/// Set to true if transactions in the result must have correct fees and prevouts.
+/// Set to false if the response must include every supplied transaction.
 fn prepare_txs(
     txs: Vec<(Transaction, Option<BlockId>)>,
     query: &Query,

--- a/src/util/transaction.rs
+++ b/src/util/transaction.rs
@@ -85,25 +85,21 @@ pub fn is_spendable(txout: &TxOut) -> bool {
 pub fn extract_tx_prevouts<'a>(
     tx: &Transaction,
     txos: &'a HashMap<OutPoint, TxOut>,
-    allow_missing: bool,
 ) -> Result<HashMap<u32, &'a TxOut>, errors::Error> {
     tx.input
         .iter()
         .enumerate()
         .filter(|(_, txi)| has_prevout(txi))
-        .filter_map(|(index, txi)| {
-            Some(Ok((
+        .map(|(index, txi)| {
+            Ok((
                 index as u32,
-                match (allow_missing, txos.get(&txi.previous_output)) {
-                    (_, Some(txo)) => txo,
-                    (true, None) => return None,
-                    (false, None) => {
-                        return Some(Err(
-                            format!("missing outpoint {:?}", txi.previous_output).into()
-                        ));
+                match txos.get(&txi.previous_output) {
+                    Some(txo) => txo,
+                    None => {
+                        return Err(format!("missing outpoint {:?}", txi.previous_output).into());
                     }
                 },
-            )))
+            ))
         })
         .collect()
 }


### PR DESCRIPTION
Fixes an issue where transactions returned by `mempool/txs` endpoints could have underflowed fees due to missing prevouts.

`mempool.lookup_txos()` is not guaranteed to find all txos for mempool transactions. When we later use the result of `mempool.lookup_txos()` to create new TransactionValue objects, some prevout values may be missing causing incorrect fees to be calculated.

If the missing prevouts cause the sum of output values to be greater than the sum of the (remaining) inputs, the resulting u64 fee underflows, producing absurdly high fees.

This PR ~~adds a `filter_missing_prevouts` flag to `prepare_txs`, which~~ makes `TransactionValue::new` return an error instead of a bad result if any prevouts cannot be found. Any failures are then filtered out of the final list of prepared transactions.