### PR TITLE
Protect internal apis

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -52,7 +52,7 @@ const TTL_MEMPOOL_RECENT: u32 = 5; // ttl for GET /mempool/recent
 const CONF_FINAL: usize = 10; // reorgs deeper than this are considered unlikely
 
 // internal api prefix
-const INTERNAL_PREFIX: &str = "internal-api";
+const INTERNAL_PREFIX: &str = "internal";
 
 #[derive(Serialize, Deserialize)]
 struct BlockValue {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -729,7 +729,7 @@ fn handle_request(
                 .ok_or_else(|| HttpError::not_found("Block not found".to_string()))?;
             json_response(txids, TTL_LONG)
         }
-        (&Method::GET, Some(&"block"), Some(hash), Some(&"txs"), None, None) => {
+        (&Method::GET, Some(&INTERNAL_PREFIX), Some(&"block"), Some(hash), Some(&"txs"), None) => {
             let hash = BlockHash::from_hex(hash)?;
             let txs = query
                 .chain()

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -51,6 +51,9 @@ const TTL_SHORT: u32 = 10; // ttl for volatie resources
 const TTL_MEMPOOL_RECENT: u32 = 5; // ttl for GET /mempool/recent
 const CONF_FINAL: usize = 10; // reorgs deeper than this are considered unlikely
 
+// internal api prefix
+const INTERNAL_PREFIX: &str = "internal-api";
+
 #[derive(Serialize, Deserialize)]
 struct BlockValue {
     id: String,
@@ -1165,7 +1168,14 @@ fn handle_request(
         (&Method::GET, Some(&"mempool"), Some(&"txids"), None, None, None) => {
             json_response(query.mempool().txids(), TTL_SHORT)
         }
-        (&Method::GET, Some(&"mempool"), Some(&"txs"), Some(&"all"), None, None) => {
+        (
+            &Method::GET,
+            Some(&INTERNAL_PREFIX),
+            Some(&"mempool"),
+            Some(&"txs"),
+            Some(&"all"),
+            None,
+        ) => {
             let txs = query
                 .mempool()
                 .txs()
@@ -1175,7 +1185,7 @@ fn handle_request(
 
             json_response(prepare_txs(txs, query, config), TTL_SHORT)
         }
-        (&Method::POST, Some(&"mempool"), Some(&"txs"), None, None, None) => {
+        (&Method::POST, Some(&INTERNAL_PREFIX), Some(&"mempool"), Some(&"txs"), None, None) => {
             let txid_strings: Vec<String> =
                 serde_json::from_slice(&body).map_err(|err| HttpError::from(err.to_string()))?;
 
@@ -1198,7 +1208,14 @@ fn handle_request(
                 Err(err) => http_message(StatusCode::BAD_REQUEST, err.to_string(), 0),
             }
         }
-        (&Method::GET, Some(&"mempool"), Some(&"txs"), last_seen_txid, None, None) => {
+        (
+            &Method::GET,
+            Some(&INTERNAL_PREFIX),
+            Some(&"mempool"),
+            Some(&"txs"),
+            last_seen_txid,
+            None,
+        ) => {
             let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
             let txs = query
                 .mempool()


### PR DESCRIPTION
Companion PR to https://github.com/mempool/mempool/pull/4158.

Adds an `/internal/` prefix to the following expensive bulk API endpoints.
 - `POST /internal/txs` (via #33)
 - `POST /internal/mempool/txs`
 - `GET  /internal/mempool/txs/all`
 - `GET  /internal/mempool/txs/:last-txid`