### PR TITLE
Fix Electrum RPC Hang

### DIFF
--- a/src/elements/registry.rs
+++ b/src/elements/registry.rs
@@ -102,7 +102,7 @@ impl AssetRegistry {
     }
 
     pub fn spawn_sync(asset_db: Arc<RwLock<AssetRegistry>>) -> thread::JoinHandle<()> {
-        thread::spawn(move || loop {
+        crate::util::spawn_thread("asset-registry", move || loop {
             if let Err(e) = asset_db.write().unwrap().fs_sync() {
                 error!("registry fs_sync failed: {:?}", e);
             }

--- a/src/new_index/fetch.rs
+++ b/src/new_index/fetch.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Cursor;
 use std::path::PathBuf;
-use std::sync::mpsc::Receiver;
 use std::thread;
 
 use crate::chain::{Block, BlockHash};
@@ -44,12 +43,12 @@ pub struct BlockEntry {
 type SizedBlock = (Block, u32);
 
 pub struct Fetcher<T> {
-    receiver: Receiver<T>,
+    receiver: crossbeam_channel::Receiver<T>,
     thread: thread::JoinHandle<()>,
 }
 
 impl<T> Fetcher<T> {
-    fn from(receiver: Receiver<T>, thread: thread::JoinHandle<()>) -> Self {
+    fn from(receiver: crossbeam_channel::Receiver<T>, thread: thread::JoinHandle<()>) -> Self {
         Fetcher { receiver, thread }
     }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -635,7 +635,7 @@ pub fn start(config: Arc<Config>, query: Arc<Query>) -> Handle {
 
     Handle {
         tx,
-        thread: thread::spawn(move || {
+        thread: crate::util::spawn_thread("rest-server", move || {
             run_server(config, query, rx);
         }),
     }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,5 @@
 use crossbeam_channel as channel;
 use crossbeam_channel::RecvTimeoutError;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use signal_hook::consts::{SIGINT, SIGTERM, SIGUSR1};
@@ -16,7 +15,7 @@ fn notify(signals: &[i32]) -> channel::Receiver<i32> {
     let (s, r) = channel::bounded(1);
     let mut signals =
         signal_hook::iterator::Signals::new(signals).expect("failed to register signal hook");
-    thread::spawn(move || {
+    crate::util::spawn_thread("signal-notifier", move || {
         for signal in signals.forever() {
             s.send(signal)
                 .unwrap_or_else(|_| panic!("failed to send signal {}", signal));


### PR DESCRIPTION
Edit: This PR by itself has a bug that was fixed in #49 

---

This works now.

SIGINT shuts everything down within a few milliseconds. (I only had one active connection from my local Sparrow wallet though)

You can test it by:

1. Build and run it, be sure to pass in --electrum-rpc-addr "0.0.0.0:50001" etc to allow your electrs to listen outside the container if using docker etc. (also expose the ports)
2. Wait until it says Electrum RPC started.
3. Run commands below to pummel the server with electrum requests. Wait for maybe 10 seconds or so before sending SIGINT.
4. Send a SIGINT. Pre-merge, it would freeze and not shutdown. Post-merge, the process will shut down in a few milliseconds.

## Commands

```
# Make a temp folder and cd to it
cd $(mktemp -d)

# create a new rust project
cargo new electrs-pummeler

cd electrs-pummeler

cargo add electrum-client@0.18

##### Enter the Rust code below into main.rs

# Only run the code after the Electrum RPC is listening on 50001 localhost
cargo run --release
```

```rust
use electrum_client::{bitcoin::Script, Client, ElectrumApi};
use std::thread::{sleep, spawn};
use std::time::Duration;

const LONG_WAIT_MS: u64 = 600_000;
const TINY_WAIT_MS: u64 = 10;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    for _ in 0..5000 {
        spawn(move || {
            let _client = run_new_client_in_loop("tcp://127.0.0.1:50001").unwrap();

            sleep(Duration::from_millis(LONG_WAIT_MS));
        });
        sleep(Duration::from_millis(TINY_WAIT_MS));
    }
    sleep(Duration::from_millis(LONG_WAIT_MS));
    Ok(())
}

fn run_new_client_in_loop(url: &str) -> Result<Client, Box<dyn std::error::Error>> {
    let client = Client::new(url)?;

    let _ = client.block_headers_subscribe()?;
    let mut script_bytes = [0x04, 0, 0, 0, 0];
    let mut subs = Vec::with_capacity(256);
    for i in 0..=255u8 {
        script_bytes[4] = i;
        subs.push(client.script_subscribe(Script::from_bytes(&script_bytes))?);
    }
    Ok(client)
}
```