### PR TITLE
Fix: Make error messages clearer

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -614,7 +614,10 @@ fn get_history(
 ) -> Result<Vec<(Txid, Option<BlockId>)>> {
     // to avoid silently trunacting history entries, ask for one extra more than the limit and fail if it exists
     let history_txids = query.history_txids(scripthash, txs_limit + 1);
-    ensure!(history_txids.len() <= txs_limit, ErrorKind::TooPopular);
+    ensure!(
+        history_txids.len() <= txs_limit,
+        ErrorKind::TooManyTxs(txs_limit)
+    );
     Ok(history_txids)
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,9 +14,14 @@ error_chain! {
             display("Iterrupted by signal {}", sig)
         }
 
-        TooPopular {
-            description("Too many history entries")
-            display("Too many history entries")
+        TooManyUtxos(limit: usize) {
+            description("Too many unspent transaction outputs. Contact support to raise limits.")
+            display("Too many unspent transaction outputs (>{}). Contact support to raise limits.", limit)
+        }
+
+        TooManyTxs(limit: usize) {
+            description("Too many history transactions. Contact support to raise limits.")
+            display("Too many history transactions (>{}). Contact support to raise limits.", limit)
         }
 
         #[cfg(feature = "electrum-discovery")]

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -671,7 +671,7 @@ impl ChainQuery {
 
             // abort if the utxo set size excedees the limit at any point in time
             if utxos.len() > limit {
-                bail!(ErrorKind::TooPopular)
+                bail!(ErrorKind::TooManyUtxos(limit))
             }
         }
 


### PR DESCRIPTION
These limits should have separate error messages and be clearer about what is being limited.