### PR TITLE
Update README and rename lib to mempool-electrs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-test-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo test --package electrs --lib --all-features
+      - run: cargo test --lib --all-features
 
   clippy:
     name: Linter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,49 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "electrs"
-version = "3.0.0-dev"
-dependencies = [
- "arrayref",
- "base64 0.13.0",
- "bincode",
- "bitcoin 0.28.0",
- "bounded-vec-deque",
- "clap",
- "crossbeam-channel",
- "dirs",
- "electrum-client",
- "elements",
- "error-chain",
- "glob",
- "hex",
- "hyper",
- "hyperlocal",
- "itertools",
- "lazy_static",
- "libc",
- "log",
- "num_cpus",
- "page_size",
- "prometheus",
- "rayon",
- "rocksdb",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2",
- "signal-hook",
- "socket2",
- "stderrlog",
- "sysconf",
- "tempfile",
- "time 0.3.9",
- "tiny_http",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "electrum-client"
 version = "0.8.0"
 source = "git+https://github.com/Blockstream/rust-electrum-client?rev=d3792352992a539afffbe11501d1aff9fd5b919d#d3792352992a539afffbe11501d1aff9fd5b919d"
@@ -861,6 +818,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg 1.1.0",
+]
+
+[[package]]
+name = "mempool-electrs"
+version = "3.0.0-dev"
+dependencies = [
+ "arrayref",
+ "base64 0.13.0",
+ "bincode",
+ "bitcoin 0.28.0",
+ "bounded-vec-deque",
+ "clap",
+ "crossbeam-channel",
+ "dirs",
+ "electrum-client",
+ "elements",
+ "error-chain",
+ "glob",
+ "hex",
+ "hyper",
+ "hyperlocal",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "log",
+ "num_cpus",
+ "page_size",
+ "prometheus",
+ "rayon",
+ "rocksdb",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "signal-hook",
+ "socket2",
+ "stderrlog",
+ "sysconf",
+ "tempfile",
+ "time 0.3.9",
+ "tiny_http",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,23 @@
 [package]
-name = "electrs"
+name = "mempool-electrs"
 version = "3.0.0-dev"
-authors = ["Roman Zeyde <me@romanzey.de>"]
+authors = [
+    "Roman Zeyde <me@romanzey.de>",
+    "Nadav Ivgi <nadav@shesek.info>",
+    "wiz <j@wiz.biz>",
+    "junderw <jonathan.underwood4649@gmail.com>"
+]
 description = "An efficient re-implementation of Electrum Server in Rust"
 license = "MIT"
 homepage = "https://github.com/mempool/electrs"
 repository = "https://github.com/mempool/electrs"
+publish = false
 keywords = ["bitcoin", "electrum", "server", "index", "database"]
-documentation = "https://docs.rs/electrs/"
 readme = "README.md"
 edition = "2018"
+
+[lib]
+name = "electrs"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Esplora - Electrs backend API
+# Mempool - Electrs backend API
 
-A block chain index engine and HTTP API written in Rust based on [romanz/electrs](https://github.com/romanz/electrs).
+A block chain index engine and HTTP API written in Rust based on [romanz/electrs](https://github.com/romanz/electrs) and [Blockstream/electrs](https://github.com/Blockstream/electrs).
 
-Used as the backend for the [Esplora block explorer](https://github.com/Blockstream/esplora) powering [blockstream.info](https://blockstream.info/).
+Used as the backend for the [mempool block explorer](https://github.com/mempool/mempool) powering [mempool.space](https://mempool.space/).
 
-API documentation [is available here](https://github.com/blockstream/esplora/blob/master/API.md).
+API documentation [is available here](https://mempool.space/docs/api/rest).
 
 Documentation for the database schema and indexing process [is available here](doc/schema.md).
 
@@ -13,8 +13,8 @@ Documentation for the database schema and indexing process [is available here](d
 Install Rust, Bitcoin Core (no `txindex` needed) and the `clang` and `cmake` packages, then:
 
 ```bash
-$ git clone https://github.com/blockstream/electrs && cd electrs
-$ git checkout new-index
+$ git clone https://github.com/mempool/electrs && cd electrs
+$ git checkout mempool
 $ cargo run --release --bin electrs -- -vvvv --daemon-dir ~/.bitcoin
 
 # Or for liquid:
@@ -24,11 +24,9 @@ $ cargo run --features liquid --release --bin electrs -- -vvvv --network liquid 
 See [electrs's original documentation](https://github.com/romanz/electrs/blob/master/doc/usage.md) for more detailed instructions.
 Note that our indexes are incompatible with electrs's and has to be created separately.
 
-The indexes require 610GB of storage after running compaction (as of June 2020), but you'll need to have
+The indexes require 1.3TB of storage after running compaction (as of October 2023), but you'll need to have
 free space of about double that available during the index compaction process.
-Creating the indexes should take a few hours on a beefy machine with SSD.
-
-To deploy with Docker, follow the [instructions here](https://github.com/Blockstream/esplora#how-to-build-the-docker-image).
+Creating the indexes should take a few hours on a beefy machine with high speed NVMe SSD(s).
 
 ### Light mode
 
@@ -78,7 +76,7 @@ Additional options with the `electrum-discovery` feature:
 - `--electrum-hosts <json>` - a json map of the public hosts where the electrum server is reachable, in the [`server.features` format](https://electrumx.readthedocs.io/en/latest/protocol-methods.html#server.features).
 - `--electrum-announce` - announce the electrum server on the electrum p2p server discovery network.
 
-See `$ cargo run --release --bin electrs -- --help` for the full list of options.
+See `$ cargo run --bin electrs -- --help` for the full list of options.
 
 ## License
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -59,4 +59,4 @@ cargo clippy $@ -q -F electrum-discovery,liquid
 
 TESTNAME="Running cargo test with all features"
 echo "$TESTNAME"
-cargo test $@ -q --package electrs --lib --all-features
+cargo test $@ -q --lib --all-features

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,7 +85,7 @@ impl Config {
     pub fn from_args() -> Config {
         let network_help = format!("Select network type ({})", Network::names().join(", "));
 
-        let args = App::new("Electrum Rust Server")
+        let args = App::new("Mempool Electrum Rust Server")
             .version(crate_version!())
             .arg(
                 Arg::with_name("version")


### PR DESCRIPTION
Closes #60 

1. Update README
2. Change name of library package to mempool-electrs (binary name of `--bin electrs` does not change.)
3. Added authors
4. Removed useless docsrs documentation (the library is not documented and is useless anyways, since it's a binary)