### PR TITLE
ThreadPoolBuilder can fail when resources are busy

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1087,11 +1087,23 @@ fn lookup_txos(
     outpoints: &BTreeSet<OutPoint>,
     allow_missing: bool,
 ) -> HashMap<OutPoint, TxOut> {
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(16) // we need to saturate SSD IOPS
-        .thread_name(|i| format!("lookup-txo-{}", i))
-        .build()
-        .unwrap();
+    let mut loop_count = 10;
+    let pool = loop {
+        match rayon::ThreadPoolBuilder::new()
+            .num_threads(16) // we need to saturate SSD IOPS
+            .thread_name(|i| format!("lookup-txo-{}", i))
+            .build()
+        {
+            Ok(pool) => break pool,
+            Err(e) => {
+                if loop_count == 0 {
+                    panic!("schema::lookup_txos failed to create a ThreadPool: {}", e);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                loop_count -= 1;
+            }
+        }
+    };
     pool.install(|| {
         outpoints
             .par_iter()


### PR DESCRIPTION
Fixes #67

This is a temp fix.

Long term, we should probably maintain a single global persistent ThreadPool instead of spinning up a new pool for every request.