### PR TITLE
Feature: Configurable loop delay and bitcoind-only broadcast endpoint

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -107,7 +107,7 @@ fn run_server(config: Arc<Config>) -> Result<()> {
     }
 
     loop {
-        if let Err(err) = signal.wait(Duration::from_millis(500), true) {
+        if let Err(err) = signal.wait(Duration::from_millis(config.main_loop_delay), true) {
             info!("stopping server: {}", err);
 
             electrs::util::spawn_thread("shutdown-thread-checker", || {

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub monitoring_addr: SocketAddr,
     pub jsonrpc_import: bool,
     pub light_mode: bool,
+    pub main_loop_delay: u64,
     pub address_search: bool,
     pub index_unspendables: bool,
     pub cors: Option<String>,
@@ -167,6 +168,12 @@ impl Config {
                 Arg::with_name("light_mode")
                     .long("lightmode")
                     .help("Enable light mode for reduced storage")
+            )
+            .arg(
+                Arg::with_name("main_loop_delay")
+                    .long("main-loop-delay")
+                    .help("The number of milliseconds the main loop will wait between loops. (Can be shortened with SIGUSR1)")
+                    .default_value("500")
             )
             .arg(
                 Arg::with_name("address_search")
@@ -494,6 +501,7 @@ impl Config {
             rest_max_mempool_page_size: value_t_or_exit!(m, "rest_max_mempool_page_size", usize),
             jsonrpc_import: m.is_present("jsonrpc_import"),
             light_mode: m.is_present("light_mode"),
+            main_loop_delay: value_t_or_exit!(m, "main_loop_delay", u64),
             address_search: m.is_present("address_search"),
             index_unspendables: m.is_present("index_unspendables"),
             cors: m.value_of("cors").map(|s| s.to_string()),

--- a/start
+++ b/start
@@ -77,6 +77,7 @@ do
 	# prepare run-time variables
 	UTXOS_LIMIT=500
 	ELECTRUM_TXS_LIMIT=500
+	MAIN_LOOP_DELAY=500
 	DAEMON_CONF="${HOME}/${DAEMON}.conf"
 	HTTP_SOCKET_FILE="${HOME}/socket/esplora-${DAEMON}-${NETWORK}"
 	RPC_SOCKET_FILE="${HOME}/socket/electrum-${DAEMON}-${NETWORK}"
@@ -90,6 +91,7 @@ do
 	if [ "${NODENAME}" = "node201" ];then
 		UTXOS_LIMIT=9000
 		ELECTRUM_TXS_LIMIT=9000
+		MAIN_LOOP_DELAY=14000
 	fi
 
 	# Run the popular address txt file generator before each run
@@ -127,6 +129,7 @@ do
 		--network "${NETWORK}" \
 		--daemon-dir "${HOME}" \
 		--db-dir "${DB_FOLDER}" \
+		--main-loop-delay "${MAIN_LOOP_DELAY}" \
 		--rpc-socket-file "${RPC_SOCKET_FILE}" \
 		--http-socket-file "${HTTP_SOCKET_FILE}" \
 		--precache-scripts "${POPULAR_SCRIPTS_FILE}" \


### PR DESCRIPTION
1. `--main-loop-delay` for setting the millisecond delay in main loop.
2. `POST /tx/noupdate` for bitcoind only broadcast