### PR TITLE
Add paged mempool txids endpoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,7 @@ pub struct Config {
     pub rest_default_chain_txs_per_page: usize,
     pub rest_default_max_mempool_txs: usize,
     pub rest_max_mempool_page_size: usize,
+    pub rest_max_mempool_txid_page_size: usize,
 
     #[cfg(feature = "liquid")]
     pub parent_network: BNetwork,
@@ -244,6 +245,12 @@ impl Config {
                     .long("rest-max-mempool-page-size")
                     .help("The maximum number of transactions returned by the paginated /internal/mempool/txs endpoint.")
                     .default_value("1000")
+            )
+            .arg(
+                Arg::with_name("rest_max_mempool_txid_page_size")
+                    .long("rest-max-mempool-txid-page-size")
+                    .help("The maximum number of transactions returned by the paginated /mempool/txids/page endpoint.")
+                    .default_value("10000")
             )
             .arg(
                 Arg::with_name("electrum_txs_limit")
@@ -499,6 +506,11 @@ impl Config {
                 usize
             ),
             rest_max_mempool_page_size: value_t_or_exit!(m, "rest_max_mempool_page_size", usize),
+            rest_max_mempool_txid_page_size: value_t_or_exit!(
+                m,
+                "rest_max_mempool_txid_page_size",
+                usize
+            ),
             jsonrpc_import: m.is_present("jsonrpc_import"),
             light_mode: m.is_present("light_mode"),
             main_loop_delay: value_t_or_exit!(m, "main_loop_delay", u64),

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -288,6 +288,21 @@ impl Mempool {
         self.txstore.keys().collect()
     }
 
+    // Get n txids after the given txid in the mempool
+    pub fn txids_page(&self, n: usize, start: Option<Txid>) -> Vec<&Txid> {
+        let _timer = self.latency.with_label_values(&["txs"]).start_timer();
+        let start_bound = match start {
+            Some(txid) => Excluded(txid),
+            None => Unbounded,
+        };
+
+        self.txstore
+            .range((start_bound, Unbounded))
+            .take(n)
+            .map(|(k, _v)| k)
+            .collect()
+    }
+
     // Get all txs in the mempool
     pub fn txs(&self) -> Vec<Transaction> {
         let _timer = self.latency.with_label_values(&["txs"]).start_timer();

--- a/src/new_index/mempool.rs
+++ b/src/new_index/mempool.rs
@@ -290,7 +290,10 @@ impl Mempool {
 
     // Get n txids after the given txid in the mempool
     pub fn txids_page(&self, n: usize, start: Option<Txid>) -> Vec<&Txid> {
-        let _timer = self.latency.with_label_values(&["txs"]).start_timer();
+        let _timer = self
+            .latency
+            .with_label_values(&["txids_page"])
+            .start_timer();
         let start_bound = match start {
             Some(txid) => Excluded(txid),
             None => Unbounded,
@@ -311,7 +314,7 @@ impl Mempool {
 
     // Get n txs after the given txid in the mempool
     pub fn txs_page(&self, n: usize, start: Option<Txid>) -> Vec<Transaction> {
-        let _timer = self.latency.with_label_values(&["txs"]).start_timer();
+        let _timer = self.latency.with_label_values(&["txs_page"]).start_timer();
         let mut page = Vec::with_capacity(n);
         let start_bound = match start {
             Some(txid) => Excluded(txid),

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1256,6 +1256,17 @@ fn handle_request(
         (&Method::GET, Some(&"mempool"), Some(&"txids"), None, None, None) => {
             json_response(query.mempool().txids(), TTL_SHORT)
         }
+        (&Method::GET, Some(&"mempool"), Some(&"txids"), Some(&"page"), last_seen_txid, None) => {
+            let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
+            let max_txs = query_params
+                .get("max_txs")
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(config.rest_max_mempool_txid_page_size);
+            json_response(
+                query.mempool().txids_page(max_txs, last_seen_txid),
+                TTL_SHORT,
+            )
+        }
         (
             &Method::GET,
             Some(&INTERNAL_PREFIX),


### PR DESCRIPTION
The `/mempool/txids` endpoint returns every txid in the mempool, which can be slow enough to time out when there are a very large number of transactions.

This PR is one of two options for an alternative endpoint to allow the contents of the mempool to be queried in a series of smaller non-overlapping requests.

This option is a "paged" endpoint `/mempool/txids/page/<last_txid>?max_txs=n`.

The other option is a "chunked" endpoint via PR #73.

Here, `<last_txid>` is an optional URL parameter representing the last txid of the previous page (or left blank if this is the first request), and `max_txs` is an optional query parameter setting the page size (defaults to 10000, which is also configurable at runtime via a new `rest_max_mempool_txid_page_size` argument).

This provides stable pagination even when transactions are added and removed between requests.

I'd expect this endpoint to be used something like:
```javascript
let all_txids = [];
let last_txid = null;
while (true) {
  const result = await fetch(`https://mempool.space/api/mempool/txids/page/${last_txid || ''}`);
  const txids = await result.json();
  if (txids.length) {
    last_txid = txids[txids.length - 1];
    all_txids = all_txids.concat(txids);
  } else {
    break;
  }
}
```
