### PR TITLE
Add /address/:addr/txs/summary endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,12 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,16 +661,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -861,7 +839,6 @@ dependencies = [
  "hex",
  "hyper",
  "hyperlocal",
- "indexmap",
  "itertools",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +673,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -839,6 +861,7 @@ dependencies = [
  "hex",
  "hyper",
  "hyperlocal",
+ "indexmap",
  "itertools",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ tokio = { version = "1", features = ["sync", "macros"] }
 
 # optional dependencies for electrum-discovery
 electrum-client = { version = "0.8", optional = true }
-indexmap = "2.2.5"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ name = "electrs"
 
 [features]
 default = []
-liquid = [ "elements" ]
-electrum-discovery = [ "electrum-client"]
+liquid = ["elements"]
+electrum-discovery = ["electrum-client"]
 
 [dependencies]
 arrayref = "0.3.6"
@@ -64,6 +64,7 @@ tokio = { version = "1", features = ["sync", "macros"] }
 
 # optional dependencies for electrum-discovery
 electrum-client = { version = "0.8", optional = true }
+indexmap = "2.2.5"
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub rest_default_block_limit: usize,
     pub rest_default_chain_txs_per_page: usize,
     pub rest_default_max_mempool_txs: usize,
+    pub rest_default_max_address_summary_txs: usize,
     pub rest_max_mempool_page_size: usize,
     pub rest_max_mempool_txid_page_size: usize,
 
@@ -239,6 +240,12 @@ impl Config {
                     .long("rest-default-max-mempool-txs")
                     .help("The default number of mempool transactions returned by the txs endpoints.")
                     .default_value("50")
+            )
+            .arg(
+                Arg::with_name("rest_default_max_address_summary_txs")
+                    .long("rest-default-max-address-summary-txs")
+                    .help("The default number of transactions returned by the address summary endpoints.")
+                    .default_value("5000")
             )
             .arg(
                 Arg::with_name("rest_max_mempool_page_size")
@@ -503,6 +510,11 @@ impl Config {
             rest_default_max_mempool_txs: value_t_or_exit!(
                 m,
                 "rest_default_max_mempool_txs",
+                usize
+            ),
+            rest_default_max_address_summary_txs: value_t_or_exit!(
+                m,
+                "rest_default_max_address_summary_txs",
                 usize
             ),
             rest_max_mempool_page_size: value_t_or_exit!(m, "rest_max_mempool_page_size", usize),

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -2,6 +2,7 @@ use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 #[cfg(not(feature = "liquid"))]
 use bitcoin::util::merkleblock::MerkleBlock;
 use bitcoin::VarInt;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
@@ -510,6 +511,100 @@ impl ChainQuery {
             &TxHistoryRow::filter(code, hash),
             &TxHistoryRow::prefix_end(code, hash),
         )
+    }
+
+    pub fn summary(
+        &self,
+        scripthash: &[u8],
+        last_seen_txid: Option<&Txid>,
+        limit: usize,
+    ) -> Vec<TxHistorySummary> {
+        // scripthash lookup
+        self._summary(b'H', scripthash, last_seen_txid, limit)
+    }
+
+    fn _summary(
+        &self,
+        code: u8,
+        hash: &[u8],
+        last_seen_txid: Option<&Txid>,
+        limit: usize,
+    ) -> Vec<TxHistorySummary> {
+        let _timer_scan = self.start_timer("address_summary");
+        let rows = self
+            .history_iter_scan_reverse(code, hash)
+            .map(TxHistoryRow::from_row)
+            .map(|row| (row.get_txid(), row.key.txinfo))
+            .skip_while(|(txid, _)| {
+                // skip until we reach the last_seen_txid
+                last_seen_txid.map_or(false, |last_seen_txid| last_seen_txid != txid)
+            })
+            .skip_while(|(txid, _)| {
+                // skip the last_seen_txid itself
+                last_seen_txid.map_or(false, |last_seen_txid| last_seen_txid == txid)
+            })
+            .filter_map(|(txid, info)| {
+                self.tx_confirming_block(&txid)
+                    .map(|b| (txid, info, b.height, b.time))
+            });
+
+        // collate utxo funding/spending events by transaction
+        let mut map: IndexMap<Txid, TxHistorySummary> = IndexMap::new();
+        for (txid, info, height, time) in rows {
+            if !map.contains_key(&txid) && map.len() == limit {
+                break;
+            }
+            match info {
+                #[cfg(not(feature = "liquid"))]
+                TxHistoryInfo::Funding(info) => {
+                    map.entry(txid)
+                        .and_modify(|tx| {
+                            tx.value = tx.value.saturating_add(info.value.try_into().unwrap_or(0))
+                        })
+                        .or_insert(TxHistorySummary {
+                            txid,
+                            value: info.value.try_into().unwrap_or(0),
+                            height,
+                            time,
+                        });
+                }
+                #[cfg(not(feature = "liquid"))]
+                TxHistoryInfo::Spending(info) => {
+                    map.entry(txid)
+                        .and_modify(|tx| {
+                            tx.value = tx.value.saturating_sub(info.value.try_into().unwrap_or(0))
+                        })
+                        .or_insert(TxHistorySummary {
+                            txid,
+                            value: 0_i64.saturating_sub(info.value.try_into().unwrap_or(0)),
+                            height,
+                            time,
+                        });
+                }
+                #[cfg(feature = "liquid")]
+                TxHistoryInfo::Funding(_info) => {
+                    map.entry(txid).or_insert(TxHistorySummary {
+                        txid,
+                        value: 0,
+                        height,
+                        time,
+                    });
+                }
+                #[cfg(feature = "liquid")]
+                TxHistoryInfo::Spending(_info) => {
+                    map.entry(txid).or_insert(TxHistorySummary {
+                        txid,
+                        value: 0,
+                        height,
+                        time,
+                    });
+                }
+                #[cfg(feature = "liquid")]
+                _ => {}
+            }
+        }
+
+        map.into_values().collect()
     }
 
     pub fn history(
@@ -1571,6 +1666,14 @@ impl TxHistoryInfo {
             | TxHistoryInfo::Pegout(_) => unreachable!(),
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TxHistorySummary {
+    txid: Txid,
+    height: usize,
+    value: i64,
+    time: u32,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -975,7 +975,7 @@ fn handle_request(
         ) => {
             let script_hash = to_scripthash(script_type, script_str, config.network_type)?;
             let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
-            let max_txs = cmp::max(
+            let max_txs = cmp::min(
                 config.rest_default_max_address_summary_txs,
                 query_params
                     .get("max_txs")


### PR DESCRIPTION
This PR adds a new `/address/:address/txs/summary/(last_seen_txid?)` endpoint which returns a condensed list of recent confirmed transactions related to an address combined with the blockheight, time, and net balance change.

The endpoint is paginated using the usual `last_seen_txid` format, with a maximum number of transactions configurable via `--rest-default-max-address-summary-txs` (default 5000).

Results are returned in the following format:

```
[
  {"txid":"7b7c9e70071f29a313caf8647cb9dc1790c5bd7de0e8f5920df478e50b715cc8","height":835193,"value":2549627168,"time":1710748543},
  {"txid":"80422fa3e348d5cc3f635a865be162e38d587366ca2cd859dee8f0b4709d2e55","height":835192,"value":-4340898,"time":1710748355},
  {"txid":"c31190e57a7756c32f9c7d1e6a9f2331f448328d75d9b8857bb611b0d221d13f","height":835192,"value":-9389074995,"time":1710748355},
  {"txid":"e31299b80f1666c9be00b9cc223bee646134f5312ddf40884af3fe8f5d83868b","height":835190,"value":-7016,"time":1710747746},
  {"txid":"23a0f71d70c6b244ccb246b480c3e645a81fb257131deac1a3bd7a98ace9d19b","height":835190,"value":2751,"time":1710747746},
]
```