### PR TITLE
Add testmempoolaccept endpoint

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -117,6 +117,26 @@ struct NetworkInfo {
     relayfee: f64, // in BTC/kB
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct MempoolFees {
+    base: f64,
+    #[serde(rename = "effective-feerate")]
+    effective_feerate: f64,
+    #[serde(rename = "effective-includes")]
+    effective_includes: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MempoolAcceptResult {
+    txid: String,
+    wtxid: String,
+    allowed: Option<bool>,
+    vsize: Option<u32>,
+    fees: Option<MempoolFees>,
+    #[serde(rename = "reject-reason")]
+    reject_reason: Option<String>,
+}
+
 pub trait CookieGetter: Send + Sync {
     fn get(&self) -> Result<Vec<u8>>;
 }
@@ -580,6 +600,12 @@ impl Daemon {
         let txid = self.request("sendrawtransaction", json!([txhex]))?;
         Txid::from_hex(txid.as_str().chain_err(|| "non-string txid")?)
             .chain_err(|| "failed to parse txid")
+    }
+
+    pub fn test_mempool_accept(&self, txhex: Vec<String>) -> Result<Vec<MempoolAcceptResult>> {
+        let result = self.request("testmempoolaccept", json!([txhex]))?;
+        serde_json::from_value::<Vec<MempoolAcceptResult>>(result)
+            .chain_err(|| "invalid testmempoolaccept reply")
     }
 
     // Get estimated feerates for the provided confirmation targets using a batch RPC request

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -602,8 +602,16 @@ impl Daemon {
             .chain_err(|| "failed to parse txid")
     }
 
-    pub fn test_mempool_accept(&self, txhex: Vec<String>) -> Result<Vec<MempoolAcceptResult>> {
-        let result = self.request("testmempoolaccept", json!([txhex]))?;
+    pub fn test_mempool_accept(
+        &self,
+        txhex: Vec<String>,
+        maxfeerate: Option<f32>,
+    ) -> Result<Vec<MempoolAcceptResult>> {
+        let params = match maxfeerate {
+            Some(rate) => json!([txhex, format!("{:.8}", rate)]),
+            None => json!([txhex]),
+        };
+        let result = self.request("testmempoolaccept", params)?;
         serde_json::from_value::<Vec<MempoolAcceptResult>>(result)
             .chain_err(|| "invalid testmempoolaccept reply")
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -605,7 +605,7 @@ impl Daemon {
     pub fn test_mempool_accept(
         &self,
         txhex: Vec<String>,
-        maxfeerate: Option<f32>,
+        maxfeerate: Option<f64>,
     ) -> Result<Vec<MempoolAcceptResult>> {
         let params = match maxfeerate {
             Some(rate) => json!([txhex, format!("{:.8}", rate)]),

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -90,7 +90,7 @@ impl Query {
     pub fn test_mempool_accept(
         &self,
         txhex: Vec<String>,
-        maxfeerate: Option<f32>,
+        maxfeerate: Option<f64>,
     ) -> Result<Vec<MempoolAcceptResult>> {
         self.daemon.test_mempool_accept(txhex, maxfeerate)
     }

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -87,8 +87,12 @@ impl Query {
         Ok(txid)
     }
 
-    pub fn test_mempool_accept(&self, txhex: Vec<String>) -> Result<Vec<MempoolAcceptResult>> {
-        self.daemon.test_mempool_accept(txhex)
+    pub fn test_mempool_accept(
+        &self,
+        txhex: Vec<String>,
+        maxfeerate: Option<f32>,
+    ) -> Result<Vec<MempoolAcceptResult>> {
+        self.daemon.test_mempool_accept(txhex, maxfeerate)
     }
 
     pub fn utxo(&self, scripthash: &[u8]) -> Result<Vec<Utxo>> {

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::chain::{Network, OutPoint, Transaction, TxOut, Txid};
 use crate::config::Config;
-use crate::daemon::Daemon;
+use crate::daemon::{Daemon, MempoolAcceptResult};
 use crate::errors::*;
 use crate::new_index::{ChainQuery, Mempool, ScriptStats, SpendingInput, Utxo};
 use crate::util::{is_spendable, BlockId, Bytes, TransactionStatus};
@@ -85,6 +85,10 @@ impl Query {
             );
         }
         Ok(txid)
+    }
+
+    pub fn test_mempool_accept(&self, txhex: Vec<String>) -> Result<Vec<MempoolAcceptResult>> {
+        self.daemon.test_mempool_accept(txhex)
     }
 
     pub fn utxo(&self, scripthash: &[u8]) -> Result<Vec<Utxo>> {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1215,7 +1215,7 @@ fn handle_request(
             let maxfeerate = query_params
                 .get("maxfeerate")
                 .map(|s| {
-                    s.parse::<f32>()
+                    s.parse::<f64>()
                         .map_err(|_| HttpError::from("Invalid maxfeerate".to_string()))
                 })
                 .transpose()?;

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1202,6 +1202,18 @@ fn handle_request(
                 .map_err(|err| HttpError::from(err.description().to_string()))?;
             http_message(StatusCode::OK, txid.to_hex(), 0)
         }
+        (&Method::POST, Some(&"txs"), Some(&"test"), None, None, None) => {
+            let txhexes: Vec<String> = String::from_utf8(body.to_vec())?
+                .split(',')
+                .map(|s| s.to_string())
+                .collect();
+
+            let result = query
+                .test_mempool_accept(txhexes)
+                .map_err(|err| HttpError::from(err.description().to_string()))?;
+
+            json_response(result, TTL_SHORT)
+        }
         (&Method::GET, Some(&"txs"), Some(&"outspends"), None, None, None) => {
             let txid_strings: Vec<&str> = query_params
                 .get("txids")

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1207,9 +1207,16 @@ fn handle_request(
                 .split(',')
                 .map(|s| s.to_string())
                 .collect();
+            let maxfeerate = query_params
+                .get("maxfeerate")
+                .map(|s| {
+                    s.parse::<f32>()
+                        .map_err(|_| HttpError::from("Invalid maxfeerate".to_string()))
+                })
+                .transpose()?;
 
             let result = query
-                .test_mempool_accept(txhexes)
+                .test_mempool_accept(txhexes, maxfeerate)
                 .map_err(|err| HttpError::from(err.description().to_string()))?;
 
             json_response(result, TTL_SHORT)

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1203,10 +1203,15 @@ fn handle_request(
             http_message(StatusCode::OK, txid.to_hex(), 0)
         }
         (&Method::POST, Some(&"txs"), Some(&"test"), None, None, None) => {
-            let txhexes: Vec<String> = String::from_utf8(body.to_vec())?
-                .split(',')
-                .map(|s| s.to_string())
-                .collect();
+            let txhexes: Vec<String> =
+                serde_json::from_str(String::from_utf8(body.to_vec())?.as_str())?;
+
+            if txhexes.len() > 25 {
+                Result::Err(HttpError::from(
+                    "Exceeded maximum of 25 transactions".to_string(),
+                ))?
+            }
+
             let maxfeerate = query_params
                 .get("maxfeerate")
                 .map(|s| {
@@ -1216,14 +1221,19 @@ fn handle_request(
                 .transpose()?;
 
             // pre-checks
-            txhexes.iter().try_for_each(|txhex| {
+            txhexes.iter().enumerate().try_for_each(|(index, txhex)| {
                 // each transaction must be of reasonable size (more than 60 bytes, within 400kWU standardness limit)
                 if !(120..800_000).contains(&txhex.len()) {
-                    Result::Err(HttpError::from("Invalid transaction size".to_string()))
+                    Result::Err(HttpError::from(format!(
+                        "Invalid transaction size for item {}",
+                        index
+                    )))
                 } else {
                     // must be a valid hex string
                     Vec::<u8>::from_hex(txhex)
-                        .map_err(|_| HttpError::from("Invalid transaction hex".to_string()))
+                        .map_err(|_| {
+                            HttpError::from(format!("Invalid transaction hex for item {}", index))
+                        })
                         .map(|_| ())
                 }
             })?;


### PR DESCRIPTION
This PR adds a new REST API endpoint `POST /txs/test`, which accepts a comma-separated list of transactions as raw hex strings, passes them to `testmempoolaccept`, and returns the results as JSON.