### PR TITLE
Remove maxfeerate safeguard from sendrawtransaction API

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -597,7 +597,7 @@ impl Daemon {
     }
 
     pub fn broadcast_raw(&self, txhex: &str) -> Result<Txid> {
-        let txid = self.request("sendrawtransaction", json!([txhex]))?;
+        let txid = self.request("sendrawtransaction", json!([txhex, 0]))?;
         Txid::from_hex(txid.as_str().chain_err(|| "non-string txid")?)
             .chain_err(|| "failed to parse txid")
     }


### PR DESCRIPTION
This PR sets the `maxfeerate` parameter in the `sendrawtransaction` RPC call to zero to allow transactions with any fee rate to be broadcast via the `/broadcast` and `POST /tx` REST APIs

(see https://bitcoincore.org/en/doc/26.0.0/rpc/rawtransactions/sendrawtransaction/)