### PR TITLE
Fixed regression introduced by #51

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -341,10 +341,10 @@ impl Daemon {
             let mempool = daemon.getmempoolinfo()?;
 
             let ibd_done = if network.is_regtest() {
-                info.blocks == 0 && info.headers == 0
+                info.blocks == info.headers
             } else {
-                false
-            } || !info.initialblockdownload.unwrap_or(false);
+                !info.initialblockdownload.unwrap_or(false)
+            };
 
             if mempool.loaded && ibd_done && info.blocks == info.headers {
                 break;


### PR DESCRIPTION
Commit merged as part of #51 introduced a regression that prevents the daemon from breaking out its startup wait loop when running in `regtest` mode, in scenarios where the blockchain already contains 1 or more blocks (apart from genesis).

This commit fixes the regression by only checking the equivalence between blocks and headers as the wait condition when running in `regtest` mode.