### PR TITLE
Order History events in the same confirmation height.

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -128,7 +128,7 @@ impl Network {
 
 pub fn genesis_hash(network: Network) -> BlockHash {
     #[cfg(not(feature = "liquid"))]
-    return bitcoin_genesis_hash(network.into());
+    return bitcoin_genesis_hash(network);
     #[cfg(feature = "liquid")]
     return liquid_genesis_hash(network);
 }
@@ -139,19 +139,28 @@ pub fn bitcoin_genesis_hash(network: Network) -> bitcoin::BlockHash {
             genesis_block(BNetwork::Bitcoin).block_hash();
         static ref TESTNET_GENESIS: bitcoin::BlockHash =
             genesis_block(BNetwork::Testnet).block_hash();
-        static ref TESTNET4_GENESIS: bitcoin::BlockHash =
-            BlockHash::from_str("00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043").unwrap();
+        static ref TESTNET4_GENESIS: bitcoin::BlockHash = bitcoin::BlockHash::from_str(
+            "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043"
+        )
+        .unwrap();
         static ref REGTEST_GENESIS: bitcoin::BlockHash =
             genesis_block(BNetwork::Regtest).block_hash();
         static ref SIGNET_GENESIS: bitcoin::BlockHash =
             genesis_block(BNetwork::Signet).block_hash();
     }
+    #[cfg(not(feature = "liquid"))]
     match network {
         Network::Bitcoin => *BITCOIN_GENESIS,
         Network::Testnet => *TESTNET_GENESIS,
         Network::Testnet4 => *TESTNET4_GENESIS,
         Network::Regtest => *REGTEST_GENESIS,
         Network::Signet => *SIGNET_GENESIS,
+    }
+    #[cfg(feature = "liquid")]
+    match network {
+        Network::Liquid => *BITCOIN_GENESIS,
+        Network::LiquidTestnet => *TESTNET_GENESIS,
+        Network::LiquidRegtest => *REGTEST_GENESIS,
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -295,6 +295,7 @@ pub struct Daemon {
 }
 
 impl Daemon {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         daemon_dir: PathBuf,
         blocks_dir: PathBuf,

--- a/src/elements/asset.rs
+++ b/src/elements/asset.rs
@@ -174,17 +174,16 @@ pub struct BurningInfo {
 pub fn index_confirmed_tx_assets(
     tx: &Transaction,
     confirmed_height: u32,
+    tx_position: u32,
     network: Network,
     parent_network: BNetwork,
     rows: &mut Vec<DBRow>,
 ) {
     let (history, issuances) = index_tx_assets(tx, network, parent_network);
 
-    rows.extend(
-        history.into_iter().map(|(asset_id, info)| {
-            asset_history_row(&asset_id, confirmed_height, info).into_row()
-        }),
-    );
+    rows.extend(history.into_iter().map(|(asset_id, info)| {
+        asset_history_row(&asset_id, confirmed_height, tx_position, info).into_row()
+    }));
 
     // the initial issuance is kept twice: once in the history index under I<asset><height><txid:vin>,
     // and once separately under i<asset> for asset lookup with some more associated metadata.
@@ -336,12 +335,14 @@ fn index_tx_assets(
 fn asset_history_row(
     asset_id: &AssetId,
     confirmed_height: u32,
+    tx_position: u32,
     txinfo: TxHistoryInfo,
 ) -> TxHistoryRow {
     let key = TxHistoryKey {
         code: b'I',
         hash: full_hash(&asset_id.into_inner()[..]),
         confirmed_height,
+        tx_position,
         txinfo,
     };
     TxHistoryRow { key }

--- a/src/elements/asset.rs
+++ b/src/elements/asset.rs
@@ -174,7 +174,7 @@ pub struct BurningInfo {
 pub fn index_confirmed_tx_assets(
     tx: &Transaction,
     confirmed_height: u32,
-    tx_position: u32,
+    tx_position: u16,
     network: Network,
     parent_network: BNetwork,
     rows: &mut Vec<DBRow>,
@@ -335,7 +335,7 @@ fn index_tx_assets(
 fn asset_history_row(
     asset_id: &AssetId,
     confirmed_height: u32,
-    tx_position: u32,
+    tx_position: u16,
     txinfo: TxHistoryInfo,
 ) -> TxHistoryRow {
     let key = TxHistoryKey {

--- a/src/elements/peg.rs
+++ b/src/elements/peg.rs
@@ -19,7 +19,13 @@ pub fn get_pegout_data(
     let pegged_asset_id = network.pegged_asset()?;
     txout.pegout_data().filter(|pegout| {
         pegout.asset == Asset::Explicit(*pegged_asset_id)
-            && pegout.genesis_hash == bitcoin_genesis_hash(parent_network)
+            && pegout.genesis_hash
+                == bitcoin_genesis_hash(match parent_network {
+                    BNetwork::Bitcoin => Network::Liquid,
+                    BNetwork::Testnet => Network::LiquidTestnet,
+                    BNetwork::Signet => return false,
+                    BNetwork::Regtest => Network::LiquidRegtest,
+                })
     })
 }
 

--- a/src/new_index/db.rs
+++ b/src/new_index/db.rs
@@ -5,7 +5,11 @@ use std::path::Path;
 use crate::config::Config;
 use crate::util::{bincode_util, Bytes};
 
-static DB_VERSION: u32 = 1;
+/// Each version will break any running instance with a DB that has a differing version.
+/// It will also break if light mode is enabled or disabled.
+// 1 = Original DB (since fork from Blockstream)
+// 2 = Add tx position to TxHistory rows and place Spending before Funding
+static DB_VERSION: u32 = 2;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct DBRow {

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1251,7 +1251,7 @@ fn index_blocks(
                 index_transaction(
                     tx,
                     height,
-                    idx as u32,
+                    idx as u16,
                     previous_txos_map,
                     &mut rows,
                     iconfig,
@@ -1268,14 +1268,14 @@ fn index_blocks(
 fn index_transaction(
     tx: &Transaction,
     confirmed_height: u32,
-    tx_position: u32,
+    tx_position: u16,
     previous_txos_map: &HashMap<OutPoint, TxOut>,
     rows: &mut Vec<DBRow>,
     iconfig: &IndexerConfig,
 ) {
     // persist history index:
-    //      H{funding-scripthash}{funding-height}F{funding-txid:vout} → ""
-    //      H{funding-scripthash}{spending-height}S{spending-txid:vin}{funding-txid:vout} → ""
+    //      H{funding-scripthash}{spending-height}{spending-block-pos}S{spending-txid:vin}{funding-txid:vout} → ""
+    //      H{funding-scripthash}{funding-height}{funding-block-pos}F{funding-txid:vout} → ""
     // persist "edges" for fast is-this-TXO-spent check
     //      S{funding-txid:vout}{spending-txid:vin} → ""
     let txid = full_hash(&tx.txid()[..]);
@@ -1616,7 +1616,7 @@ pub struct TxHistoryKey {
     pub code: u8,              // H for script history or I for asset history (elements only)
     pub hash: FullHash, // either a scripthash (always on bitcoin) or an asset id (elements only)
     pub confirmed_height: u32, // MUST be serialized as big-endian (for correct scans).
-    pub tx_position: u32, // MUST be serialized as big-endian (for correct scans). Position in block.
+    pub tx_position: u16, // MUST be serialized as big-endian (for correct scans). Position in block.
     pub txinfo: TxHistoryInfo,
 }
 
@@ -1628,7 +1628,7 @@ impl TxHistoryRow {
     fn new(
         script: &Script,
         confirmed_height: u32,
-        tx_position: u32,
+        tx_position: u16,
         txinfo: TxHistoryInfo,
     ) -> Self {
         let key = TxHistoryKey {
@@ -1867,7 +1867,7 @@ mod tests {
                 // confirmed_height
                 0, 0, 0, 2,
                 // tx_position
-                0, 0, 0, 3,
+                0, 3,
                 // TxHistoryInfo variant (Funding)
                 0, 0, 0, 1,
                 // FundingInfo
@@ -1888,7 +1888,7 @@ mod tests {
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 0, 0, 0, 2,
-                0, 0, 0, 3,
+                0, 3,
                 0, 0, 0, 1,
                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
                    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -1903,7 +1903,7 @@ mod tests {
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 0, 0, 0, 2,
-                0, 0, 0, 3,
+                0, 3,
                 0, 0, 0, 0,
                 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,
                     18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,
@@ -1920,7 +1920,7 @@ mod tests {
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 0, 0, 0, 2,
-                0, 0, 0, 3,
+                0, 3,
                 0, 0, 0, 0,
                 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,
                     18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1668,7 +1668,10 @@ fn address_to_scripthash(addr: &str, network: Network) -> Result<FullHash, HttpE
         // `addr_network` will be detected as Testnet for all of them.
         addr_network == network
             || (addr_network == Network::Testnet
-                && matches!(network, Network::Regtest | Network::Signet | Network::Testnet4))
+                && matches!(
+                    network,
+                    Network::Regtest | Network::Signet | Network::Testnet4
+                ))
     };
 
     #[cfg(feature = "liquid")]


### PR DESCRIPTION
# REQUIRES RE-INDEX

# REQUIRES A LOT OF TESTING

This should fix the ordering of history entries and transactions within the same block/tx.

I think the addition of this data to the rows might cause unforseen consequences... so it needs to be tested thoroughly.

Requires a Re-Index.