### PR TITLE
Add recent utxos rest API endpoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ pub struct Config {
     pub precache_scripts: Option<String>,
     pub precache_threads: usize,
     pub utxos_limit: usize,
+    pub utxos_history_limit: usize,
     pub electrum_txs_limit: usize,
     pub electrum_banner: String,
     pub mempool_backlog_stats_ttl: u64,
@@ -217,6 +218,12 @@ impl Config {
                     .long("utxos-limit")
                     .help("Maximum number of utxos to process per address. Lookups for addresses with more utxos will fail. Applies to the Electrum and HTTP APIs.")
                     .default_value("500")
+            )
+            .arg(
+                Arg::with_name("utxos_history_limit")
+                    .long("utxos-history-limit")
+                    .help("Maximum number of history entries to process per address when looking up recent utxos.")
+                    .default_value("20000")
             )
             .arg(
                 Arg::with_name("mempool_backlog_stats_ttl")
@@ -514,6 +521,7 @@ impl Config {
             daemon_rpc_addr,
             cookie,
             utxos_limit: value_t_or_exit!(m, "utxos_limit", usize),
+            utxos_history_limit: value_t_or_exit!(m, "utxos_history_limit", usize),
             electrum_rpc_addr,
             electrum_txs_limit: value_t_or_exit!(m, "electrum_txs_limit", usize),
             electrum_banner,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1046,6 +1046,31 @@ fn handle_request(
             // XXX paging?
             json_response(utxos, TTL_SHORT)
         }
+        (
+            &Method::GET,
+            Some(script_type @ &"address"),
+            Some(script_str),
+            Some(&"utxo"),
+            Some(&"recent"),
+            None,
+        )
+        | (
+            &Method::GET,
+            Some(script_type @ &"scripthash"),
+            Some(script_str),
+            Some(&"utxo"),
+            Some(&"recent"),
+            None,
+        ) => {
+            let script_hash = to_scripthash(script_type, script_str, config.network_type)?;
+            let utxos: Vec<UtxoValue> = query
+                .recent_utxo(&script_hash[..])?
+                .into_iter()
+                .map(UtxoValue::from)
+                .collect();
+            // XXX paging?
+            json_response(utxos, TTL_SHORT)
+        }
         (&Method::GET, Some(&"address-prefix"), Some(prefix), None, None, None) => {
             if !config.address_search {
                 return Err(HttpError::from("address search disabled".to_string()));


### PR DESCRIPTION
Draft PR to add a new `/address/:address/utxo/recent` REST API endpoint, which returns the most recent `utxos_limit` confirmed utxos for the given address, plus all unconfirmed utxos, sorted in descending order of confirmation status & block height.

### Motivation

Unlike the existing `/address/:address/utxo` endpoint, this new API retrieves UTXOs by scanning address history in *reverse* chronological order, which means it can return early with useful data once it hits one of the resource limits, rather than throwing errors on addresses with excessive activity.

This makes it more suitable for e.g. utxo charts and visualizations.

### Implementation

The PR also adds a new config parameter `utxos_history_limit`, which defines the maximum number of transaction history entries to process while looking up utxos. If an address's utxos are buried beneath more than this number of history entries, the API may return early with fewer than `utxos_limit` confirmed utxos.

Results are cached under a new cache_db key prefix `b'R'`.

#### Todo
- [ ] test reorg/stale block behavior