### PR TITLE
Add support for anchor output type

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -355,6 +355,8 @@ impl TxOutValue {
             "v0_p2wsh"
         } else if is_v1_p2tr(script) {
             "v1_p2tr"
+        } else if is_anchor(script) {
+            "anchor"
         } else if script.is_provably_unspendable() {
             "provably_unspendable"
         } else if is_bare_multisig(script) {
@@ -403,6 +405,15 @@ fn is_bare_multisig(script: &Script) -> bool {
         && script[len - 2] <= opcodes::all::OP_PUSHNUM_15.into_u8()
         && script[0] >= opcodes::all::OP_PUSHNUM_1.into_u8()
         && script[0] <= script[len - 2]
+}
+
+fn is_anchor(script: &Script) -> bool {
+    let len = script.len();
+    len == 4
+        && script[0] == opcodes::all::OP_PUSHNUM_1.into_u8()
+        && script[1] == opcodes::all::OP_PUSHBYTES_2.into_u8()
+        && script[2] == 0x4e
+        && script[3] == 0x73
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
_(partially addresses https://github.com/mempool/mempool/issues/5492)_

This PR detects the new P2A output type `OP_1 <4e73>`, and sets the corresponding `scriptpubkey_type` to "anchor" where that script occurs in inputs and outputs.

#### Testing:

Check input 0 of `/testnet4/api/tx/4a89d5d1568b5cbcb4118559cb65d2357657d361a41cd96b14e74ed3d065975c`

and output 1 of `/testnet4/api/tx/cedcdf44fba328c4da7077cac914b490a1af40acecf74ca666af6b0313c8e613`

before, both will have `scriptpubkey_type="unknown"`, after it should be `scriptpubkey_type="anchor"`.