### PR TITLE
Fix Popular Scripts script when zero history

### DIFF
--- a/src/bin/popular-scripts.rs
+++ b/src/bin/popular-scripts.rs
@@ -95,8 +95,7 @@ fn run_iterator(
         "Thread ({thread_id:?}) Seeking DB to beginning of tx histories for b'H' + {}",
         hex::encode([first_byte])
     );
-    // H = 72
-    let mut compare_vec: Vec<u8> = vec![72, first_byte];
+    let mut compare_vec: Vec<u8> = vec![b'H', first_byte];
     iter.seek(&compare_vec); // Seek to beginning of our section
 
     // Insert the byte of the next section for comparing
@@ -122,7 +121,7 @@ fn run_iterator(
     while iter.valid() {
         let key = iter.key().unwrap();
 
-        if is_finished(key) {
+        if key.is_empty() || key[0] != b'H' || is_finished(key) {
             // We have left the txhistory section,
             // but we need to check the final scripthash
             send_if_popular(


### PR DESCRIPTION
This issue was found when starting from scratch with testnet4.

There were some assumptions baked into the script. We check for the assumptions now.