### PR TITLE
Make testnet4 magic constant

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -57,10 +57,17 @@ pub const LIQUID_TESTNET_PARAMS: address::AddressParams = address::AddressParams
     blech_hrp: "tlq",
 };
 
+/// Magic for testnet4, 0x1c163f28 (from BIP94) with flipped endianness.
+#[cfg(not(feature = "liquid"))]
+const TESTNET4_MAGIC: u32 = 0x283f161c;
+
 impl Network {
     #[cfg(not(feature = "liquid"))]
     pub fn magic(self) -> u32 {
-        BNetwork::from(self).magic()
+        match self {
+            Self::Testnet4 => TESTNET4_MAGIC,
+            _ => BNetwork::from(self).magic(),
+        }
     }
 
     #[cfg(feature = "liquid")]

--- a/start
+++ b/start
@@ -45,7 +45,6 @@ case "${1}" in
 	;;
 	testnet4)
 		NETWORK=testnet4
-		MAGIC=283f161c
 		THREADS=$((NPROC / 6))
 	;;
 	signet)
@@ -157,7 +156,6 @@ do
 		--precache-threads "${THREADS}" \
 		--cookie "${RPC_USER}:${RPC_PASS}" \
 		--cors '*' \
-		--magic "${MAGIC}" \
 		--address-search \
 		--utxos-limit "${UTXOS_LIMIT}" \
 		--electrum-txs-limit "${ELECTRUM_TXS_LIMIT}" \


### PR DESCRIPTION
Testnet4 should return the magic properly by default.

We can keep the magic parameter there in case someone makes use of it.