### PR TITLE
Update cargo setup method and enable arm64 builds again

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
-      #   id: qemu
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        id: qemu
 
       - name: Setup Docker buildx action
         uses: docker/setup-buildx-action@v3
@@ -90,7 +90,7 @@ jobs:
           docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
-          --platform linux/amd64 \
+          --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/electrs:$TAG \
           --tag ${{ secrets.DOCKER_HUB_USER }}/electrs:latest \
           --output "type=registry" . \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:bookworm-slim AS base
+FROM debian:latest AS base
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-RUN apt update -qy
-RUN apt install -qy librocksdb-dev curl
+RUN apt update -qy && \
+    apt install -qy librocksdb-dev curl
 
 FROM base as build
 
@@ -13,12 +13,12 @@ ENV RUSTUP_HOME=/rust
 ENV CARGO_HOME=/cargo 
 ENV PATH=/cargo/bin:/rust/bin:$PATH
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 WORKDIR /build
 COPY . .
 
-RUN cargo +nightly build --release -Z sparse-registry --bin electrs
+RUN cargo build --release --bin electrs
 
 FROM base as deploy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest AS base
+FROM debian:bookworm-slim AS base
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 FROM debian:bookworm-slim AS base
 
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 RUN apt update -qy
-RUN apt install -qy librocksdb-dev
+RUN apt install -qy librocksdb-dev curl
 
 FROM base as build
 
-RUN apt install -qy git cargo clang cmake
+RUN apt install -qy git clang cmake
+
+ENV RUSTUP_HOME=/rust
+ENV CARGO_HOME=/cargo 
+ENV PATH=/cargo/bin:/rust/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 
 WORKDIR /build
 COPY . .
 
-RUN cargo build --release --bin electrs
+RUN cargo +nightly build --release -Z sparse-registry --bin electrs
 
 FROM base as deploy
 


### PR DESCRIPTION
We disabled arm64 builds because the process was getting stuck on the `updating crates.io index` step.

This PR applies the workaround suggested [here](https://github.com/rust-lang/cargo/issues/10781#issuecomment-1163829239) so now we have working builds again but they are taking 1h40min on Github agents.