### PR TITLE
Fix address history tx ordering

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -803,7 +803,7 @@ impl ChainQuery {
 
         self.lookup_txns(
             self.history_iter_scan_reverse(code, hash, start_height)
-                .map(|row| TxHistoryRow::from_row(row))
+                .map(TxHistoryRow::from_row)
                 // XXX: unique_by() requires keeping an in-memory list of all txids, can we avoid that?
                 .unique_by(|row| row.get_txid())
                 // TODO seek directly to last seen tx without reading earlier rows
@@ -872,7 +872,7 @@ impl ChainQuery {
 
         self.lookup_txns(
             self.history_iter_scan_group_reverse(code, hashes, start_height)
-                .map(|row| TxHistoryRow::from_row(row))
+                .map(TxHistoryRow::from_row)
                 // XXX: unique_by() requires keeping an in-memory list of all txids, can we avoid that?
                 .unique_by(|row| row.get_txid())
                 .skip_while(move |row| {

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -1322,7 +1322,7 @@ impl ChainQuery {
         asset_id: &'a AssetId,
         last_seen_txid: Option<&'a Txid>,
         limit: usize,
-    ) -> impl rayon::iter::ParallelIterator<Item = Result<(Transaction, BlockId)>> + 'a {
+    ) -> impl rayon::iter::ParallelIterator<Item = Result<(Transaction, BlockId, u16)>> + 'a {
         self._history(
             b'I',
             &asset_id.into_inner()[..],

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1801,12 +1801,22 @@ fn handle_request(
                     .map(|tx| (tx, None)),
             );
 
+            let mut confirmed_txs = query
+                .chain()
+                .asset_history(&asset_id, None, config.rest_default_chain_txs_per_page)
+                .map(|res| res.map(|(tx, blockid, tx_position)| (tx, Some(blockid), tx_position)))
+                .collect::<Result<Vec<_>, _>>()?;
+            confirmed_txs.sort_unstable_by(|(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
+                blockid2
+                    .as_ref()
+                    .map(|b| b.height)
+                    .cmp(&blockid1.as_ref().map(|b| b.height))
+                    .then_with(|| tx_position2.cmp(tx_position1))
+            });
             txs.extend(
-                query
-                    .chain()
-                    .asset_history(&asset_id, None, config.rest_default_chain_txs_per_page)
-                    .map(|res| res.map(|(tx, blockid)| (tx, Some(blockid))))
-                    .collect::<Result<Vec<_>, _>>()?,
+                confirmed_txs
+                    .into_iter()
+                    .map(|(tx, blockid, _)| (tx, blockid))
             );
 
             json_response(prepare_txs(txs, query, config), TTL_SHORT)
@@ -1824,18 +1834,34 @@ fn handle_request(
             let asset_id = AssetId::from_hex(asset_str)?;
             let last_seen_txid = last_seen_txid.and_then(|txid| Txid::from_hex(txid).ok());
 
-            let txs = query
+            let mut txs = query
                 .chain()
                 .asset_history(
                     &asset_id,
                     last_seen_txid.as_ref(),
                     config.rest_default_chain_txs_per_page,
                 )
-                .map(|res| res.map(|(tx, blockid)| (tx, Some(blockid))))
+                .map(|res| res.map(|(tx, blockid, tx_position)| (tx, Some(blockid), tx_position)))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            json_response(prepare_txs(txs, query, config), TTL_SHORT)
-        }
+            txs.sort_unstable_by(
+                |(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
+                    blockid2
+                        .as_ref()
+                        .map(|b| b.height)
+                        .cmp(&blockid1.as_ref().map(|b| b.height))
+                        .then_with(|| tx_position2.cmp(tx_position1))
+                },
+            );
+
+            json_response(prepare_txs(
+                txs.into_iter().map(|(tx, blockid, _)| (tx, blockid)).collect(),
+                query,
+                config,
+            ),
+            TTL_SHORT,
+        )
+    }
 
         #[cfg(feature = "liquid")]
         (&Method::GET, Some(&"asset"), Some(asset_str), Some(&"txs"), Some(&"mempool"), None) => {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1806,17 +1806,19 @@ fn handle_request(
                 .asset_history(&asset_id, None, config.rest_default_chain_txs_per_page)
                 .map(|res| res.map(|(tx, blockid, tx_position)| (tx, Some(blockid), tx_position)))
                 .collect::<Result<Vec<_>, _>>()?;
-            confirmed_txs.sort_unstable_by(|(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
-                blockid2
-                    .as_ref()
-                    .map(|b| b.height)
-                    .cmp(&blockid1.as_ref().map(|b| b.height))
-                    .then_with(|| tx_position2.cmp(tx_position1))
-            });
+            confirmed_txs.sort_unstable_by(
+                |(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
+                    blockid2
+                        .as_ref()
+                        .map(|b| b.height)
+                        .cmp(&blockid1.as_ref().map(|b| b.height))
+                        .then_with(|| tx_position2.cmp(tx_position1))
+                },
+            );
             txs.extend(
                 confirmed_txs
                     .into_iter()
-                    .map(|(tx, blockid, _)| (tx, blockid))
+                    .map(|(tx, blockid, _)| (tx, blockid)),
             );
 
             json_response(prepare_txs(txs, query, config), TTL_SHORT)
@@ -1844,24 +1846,25 @@ fn handle_request(
                 .map(|res| res.map(|(tx, blockid, tx_position)| (tx, Some(blockid), tx_position)))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            txs.sort_unstable_by(
-                |(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
-                    blockid2
-                        .as_ref()
-                        .map(|b| b.height)
-                        .cmp(&blockid1.as_ref().map(|b| b.height))
-                        .then_with(|| tx_position2.cmp(tx_position1))
-                },
-            );
+            txs.sort_unstable_by(|(_, blockid1, tx_position1), (_, blockid2, tx_position2)| {
+                blockid2
+                    .as_ref()
+                    .map(|b| b.height)
+                    .cmp(&blockid1.as_ref().map(|b| b.height))
+                    .then_with(|| tx_position2.cmp(tx_position1))
+            });
 
-            json_response(prepare_txs(
-                txs.into_iter().map(|(tx, blockid, _)| (tx, blockid)).collect(),
-                query,
-                config,
-            ),
-            TTL_SHORT,
-        )
-    }
+            json_response(
+                prepare_txs(
+                    txs.into_iter()
+                        .map(|(tx, blockid, _)| (tx, blockid))
+                        .collect(),
+                    query,
+                    config,
+                ),
+                TTL_SHORT,
+            )
+        }
 
         #[cfg(feature = "liquid")]
         (&Method::GET, Some(&"asset"), Some(asset_str), Some(&"txs"), Some(&"mempool"), None) => {


### PR DESCRIPTION
__*REINDEX NOT REQUIRED*__

Some of the fancy rayon parallelization stuff in https://github.com/mempool/electrs/commit/2fbb0172f7cf69dc3637e75268fbe6c823089060 broke the expected ordering of results returned by `lookup_txns`, since `par_bridge` [does not guarantee order is preserved](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelBridge.html).

This causes transactions from `/address/.../txs` and `/addresses/txs` endpoints to be returned in non-deterministic order.

The actual pagination is still correct, since the order gets scrambled *after* we find the correct set of transactions to return, although it's now not always possible to tell which transaction to use for the `after_txid` param for the next page.

This PR implements a simple fix by modifying `lookup_txns` and associated methods to include `tx_position` as well as `blockid` for each transaction in the results, and then uses that data to explicitly re-sort the final results before they are returned.