### PR TITLE
[Opt.] Lightmode - Internal get block TXs now supports genesis + faster full block queries

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -518,20 +518,20 @@ impl ChainQuery {
     pub fn get_block_txs(&self, hash: &BlockHash) -> Option<Vec<Transaction>> {
         let _timer = self.start_timer("get_block_txs");
 
-        let txids: Option<Vec<Txid>> = if self.light_mode {
-            // TODO fetch block as binary from REST API instead of as hex
-            let mut blockinfo = self.daemon.getblock_raw(hash, 1).ok()?;
-            Some(serde_json::from_value(blockinfo["tx"].take()).unwrap())
+        if self.light_mode {
+            hex::decode(self.daemon.getblock_raw(hash, 0).ok()?.as_str()?)
+                .ok()
+                .and_then(|block_bytes| deserialize::<crate::chain::Block>(&block_bytes).ok())
+                .map(|block| block.txdata)
         } else {
-            self.store
+            let txid_vec: Vec<Txid> = self
+                .store
                 .txstore_db
                 .get(&BlockRow::txids_key(full_hash(&hash[..])))
                 .map(|val| {
                     bincode_util::deserialize_little(&val).expect("failed to parse block txids")
-                })
-        };
+                })?;
 
-        txids.and_then(|txid_vec| {
             let mut transactions = Vec::with_capacity(txid_vec.len());
 
             for txid in txid_vec {
@@ -542,7 +542,7 @@ impl ChainQuery {
             }
 
             Some(transactions)
-        })
+        }
     }
 
     pub fn get_block_meta(&self, hash: &BlockHash) -> Option<BlockMeta> {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -783,10 +783,20 @@ fn handle_request(
         (&Method::GET, Some(&INTERNAL_PREFIX), Some(&"block"), Some(hash), Some(&"txs"), None) => {
             let hash = BlockHash::from_hex(hash)?;
             let block_id = query.chain().blockid_by_hash(&hash);
+
+            let block_id =
+                Some(block_id.ok_or_else(|| {
+                    HttpError::not_found("Block with hash not found".to_string())
+                })?);
+
             let txs = query
                 .chain()
                 .get_block_txs(&hash)
-                .ok_or_else(|| HttpError::not_found("Block not found".to_string()))?
+                .ok_or_else(|| {
+                    HttpError::not_found(
+                        "Transactions could not be queried from block.".to_string(),
+                    )
+                })?
                 .into_iter()
                 .map(|tx| (tx, block_id.clone()))
                 .collect();


### PR DESCRIPTION
This PR hits 2 birds with one stone.

In relation to https://github.com/mempool/electrs/pull/119#issuecomment-2803481684

1. First is the genesis blocks TXN(s) are now queried right from the block hex and use no maigc. Also not network dependent. (works on any net now and future)
2. Because the block hex is a single heavy call the overhead of calling getrawtransaction up to thousands of times per block on a request for block data is removed.

Bonus, now the block hash error is separated from the txns fetch error leading to a better debugging experience.

PortlandHODL

This PR competes with https://github.com/mempool/electrs/pull/119 as a solution to the genesis block lightmode issue.

Result `curl 127.0.0.1:3000/internal/block/0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206/txs`
```
[{"txid":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b","version":1,"locktime":0,"vin":[{"txid":"0000000000000000000000000000000000000000000000000000000000000000","vout":4294967295,"prevout":null,"scriptsig":"04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73","scriptsig_asm":"OP_PUSHBYTES_4 ffff001d OP_PUSHBYTES_1 04 OP_PUSHBYTES_69 5468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73","is_coinbase":true,"sequence":4294967295}],"vout":[{"scriptpubkey":"4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac","scriptpubkey_asm":"OP_PUSHBYTES_65 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG","scriptpubkey_type":"p2pk","value":5000000000}],"size":204,"weight":816,"sigops":4,"fee":0,"status":{"confirmed":true,"block_height":0,"block_hash":"0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206","block_time":1296688602}}]
```