### PR TITLE
Feat: Add blockchain.scripthash.unsubscribe to Electrum server impl

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -308,6 +308,16 @@ impl Connection {
         Ok(status_hash)
     }
 
+    fn blockchain_scripthash_unsubscribe(&mut self, params: &[Value]) -> Result<Value> {
+        let script_hash = hash_from_value(params.first()).chain_err(|| "bad script_hash")?;
+
+        let removed = self.status_hashes.remove(&script_hash).is_some();
+        if removed {
+            self.stats.subscriptions.dec();
+        }
+        Ok(Value::Bool(removed))
+    }
+
     #[cfg(not(feature = "liquid"))]
     fn blockchain_scripthash_get_balance(&self, params: &[Value]) -> Result<Value> {
         let script_hash = hash_from_value(params.first()).chain_err(|| "bad script_hash")?;
@@ -446,6 +456,7 @@ impl Connection {
             "blockchain.scripthash.get_history" => self.blockchain_scripthash_get_history(params),
             "blockchain.scripthash.listunspent" => self.blockchain_scripthash_listunspent(params),
             "blockchain.scripthash.subscribe" => self.blockchain_scripthash_subscribe(params),
+            "blockchain.scripthash.unsubscribe" => self.blockchain_scripthash_unsubscribe(params),
             "blockchain.transaction.broadcast" => self.blockchain_transaction_broadcast(params),
             "blockchain.transaction.get" => self.blockchain_transaction_get(params),
             "blockchain.transaction.get_merkle" => self.blockchain_transaction_get_merkle(params),


### PR DESCRIPTION
Closes #121

This adds the [`blockchain.scripthash.unsubscribe`](https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-unsubscribe) method to Electrum server.

