### PR TITLE
Fix: Do not embed (dirty) in the docker built version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,8 @@ fn main() {
         // This includes untracked files
         let dirty = cmd("git", &["status", "--short"]).expect("git command works");
 
-        let git_hash = if dirty.is_empty() {
+        // Ignore Dockerfile deletion as it is expected in Docker buildx builds
+        let git_hash = if dirty.is_empty() || dirty.trim() == "D Dockerfile" {
             rev_parse
         } else {
             format!("{}(dirty)", rev_parse.trim())


### PR DESCRIPTION
I noticed all the docker builds have `(dirty)` string in their versions.

It's because Dockerfile's COPY . . doesn't copy Dockerfile because it's ignored by docker by default.

So git sees this as "you deleted Dockerfile but haven't committed it" and the status is dirty.