### PR TITLE
Fix: gitignore .core files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *~
 *.pyc
 .vscode
+*.core


### PR DESCRIPTION
`*.core` files get auto-generated on prod and cause (dirty) to appear in the version.

git should ignore them.