### PR TITLE
Add electrum verbose transaction get

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -590,6 +590,21 @@ impl Daemon {
         Ok(blocks)
     }
 
+    pub fn gettransaction_verbose(
+        &self,
+        txid: &Txid,
+        blockhash: Option<BlockHash>,
+    ) -> Result<Value> {
+        self.request(
+            "getrawtransaction",
+            json!([
+                txid.to_hex(),
+                /*verbose=*/ true,
+                blockhash.map(|b| b.to_hex())
+            ]),
+        )
+    }
+
     pub fn gettransactions(&self, txhashes: &[&Txid]) -> Result<Vec<Transaction>> {
         let params_list: Vec<Value> = txhashes
             .iter()

--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -392,9 +392,12 @@ impl Connection {
             None => false,
         };
 
-        // FIXME: implement verbose support
         if verbose {
-            bail!("verbose transactions are currently unsupported");
+            let blockid = self.query.chain().tx_confirming_block(&tx_hash);
+            return self
+                .query
+                .lookup_txn_info_verbose(&tx_hash, blockid)
+                .chain_err(|| "missing transaction");
         }
 
         let tx = self

--- a/src/new_index/query.rs
+++ b/src/new_index/query.rs
@@ -147,6 +147,14 @@ impl Query {
             .lookup_raw_txn(txid, None)
             .or_else(|| self.mempool().lookup_raw_txn(txid))
     }
+    pub fn lookup_txn_info_verbose(
+        &self,
+        txid: &Txid,
+        blockid: Option<BlockId>,
+    ) -> Result<serde_json::Value> {
+        self.daemon
+            .gettransaction_verbose(txid, blockid.map(|b| b.hash))
+    }
 
     /// Not all OutPoints from mempool transactions are guaranteed to be included in the result
     pub fn lookup_txos(&self, outpoints: &BTreeSet<OutPoint>) -> HashMap<OutPoint, TxOut> {


### PR DESCRIPTION
Adds support to the `blockchain.transaction.get` electrum method for verbose flag.

This should work without txindex because we pass the blockhash if available. (and blockhash/txindex isn't needed for mempool txes)

