### PR TITLE
enable cache_db auto compaction

### DIFF
--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -373,6 +373,7 @@ impl Indexer {
         start_fetcher(self.from, &daemon, to_index)?
             .map(|blocks| self.index(&blocks, Operation::AddBlocks));
         self.start_auto_compactions(&self.store.history_db);
+        self.start_auto_compactions(&self.store.cache_db);
 
         if let DBFlush::Disable = self.flush {
             debug!("flushing to disk");


### PR DESCRIPTION
the shared rocksdb store constructor disables auto compaction to speed up initial indexing:

https://github.com/mempool/electrs/blob/5d3907056a31eca2fe11c40b562e8344ea5bd6b4/src/new_index/db.rs#L312

and then we have to explicitly re-enable it on each store instance later:
https://github.com/mempool/electrs/blob/5d3907056a31eca2fe11c40b562e8344ea5bd6b4/src/new_index/schema.rs#L363-L365
https://github.com/mempool/electrs/blob/5d3907056a31eca2fe11c40b562e8344ea5bd6b4/src/new_index/schema.rs#L373-L375


but when the cache_db was added in [2699560], apparently auto compaction was never re-enabled for that store.

this means
- the rocksdb L0 SST files for the cache_db grow unbounded every time we flush the cache_db memtable to disk, as we do after every precache run.
- point lookups for scripthashes *not* in the cache_db (i.e. most /address/:address queries) get more and more expensive, since they have to search every L0 SST file to confirm there are no hits.
    - lookups for scripthashes that *are* in the cache are still fast, since a) they're usually still in the memtable, and b) if not, the latest entry is probably in one the first SST files we check.

in normal operation this isn't very noticeable because the cache_db is small and rarely flushed, but if you did something silly like reboot electrs and re-run the precache every hour then read performance for less popular addresses could eventually become severely degraded.